### PR TITLE
Fix image label parsing

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-- `ImageLabel` data is now correctly parsed.
+- [ome_zarr_models.v04.image_label.ImageLabel][] data is now correctly parsed.
   Previously the `'image-label'` field was loaded, but not validated or parsed.
 
 ## 0.1

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## 0.1.1
+
+### Bug fixes
+
+- `ImageLabel` data is now correctly parsed.
+  Previously the `'image-label'` field was loaded, but not validated or parsed.
+
+## 0.1
+
+First `ome-zarr-models` release.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@ nav:
           - api/v04/image-label.md
           - api/v04/labels.md
           - api/v04/well.md
+  - Changelog: changelog.md
   - Contributing: contributing.md
 
 watch:

--- a/src/ome_zarr_models/__init__.py
+++ b/src/ome_zarr_models/__init__.py
@@ -19,6 +19,10 @@ except PackageNotFoundError:  # pragma: no cover
 
 _V04_groups: list[type[BaseGroupv04]] = [
     ome_zarr_models.v04.hcs.HCS,
+    # Important that ImageLabel is higher than Image
+    # otherwise Image will happily parse an ImageLabel
+    # dataset without parsing the image-label bit of
+    # metadata
     ome_zarr_models.v04.image_label.ImageLabel,
     ome_zarr_models.v04.image.Image,
     ome_zarr_models.v04.labels.Labels,

--- a/src/ome_zarr_models/v04/image_label.py
+++ b/src/ome_zarr_models/v04/image_label.py
@@ -7,12 +7,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Self
 
 import zarr
-from pydantic import model_validator
+from pydantic import Field
 from pydantic_zarr.v2 import ArraySpec, GroupSpec
 
 from ome_zarr_models.base import BaseAttrs
 from ome_zarr_models.v04.base import BaseGroupv04
-from ome_zarr_models.v04.image import Image, _check_arrays_compatible
+from ome_zarr_models.v04.image import Image
 from ome_zarr_models.v04.image_label_types import (
     Label,
 )
@@ -33,7 +33,7 @@ class ImageLabelAttrs(BaseAttrs):
     Attributes for an image label object.
     """
 
-    image_label: Label
+    image_label: Label = Field(..., alias="image-label")
     multiscales: list[Multiscale]
 
 
@@ -41,8 +41,6 @@ class ImageLabel(GroupSpec[ImageLabelAttrs, ArraySpec | GroupSpec], BaseGroupv04
     """
     An image label dataset.
     """
-
-    _check_arrays_compatible = model_validator(mode="after")(_check_arrays_compatible)
 
     @classmethod
     def from_zarr(cls, group: zarr.Group) -> Self:
@@ -54,4 +52,6 @@ class ImageLabel(GroupSpec[ImageLabelAttrs, ArraySpec | GroupSpec], BaseGroupv04
         group : zarr.Group
             A Zarr group that has valid OME-NGFF image label metadata.
         """
-        return Image.from_zarr(group)
+        # Use Image.from_zarr() to validate multiscale metadata
+        Image.from_zarr(group)
+        return super().from_zarr(group)  # type: ignore[no-any-return]

--- a/tests/v04/conftest.py
+++ b/tests/v04/conftest.py
@@ -1,3 +1,4 @@
+import json
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, Literal, TypeVar
@@ -5,6 +6,7 @@ from typing import Any, Literal, TypeVar
 import numcodecs
 import numpy as np
 import numpy.typing as npt
+import zarr
 from numcodecs.abc import Codec
 from pydantic_zarr.v2 import ArraySpec, GroupSpec
 from zarr.util import guess_chunks
@@ -23,6 +25,18 @@ T = TypeVar("T", bound=BaseAttrs)
 def read_in_json(*, json_fname: str, model_cls: type[T]) -> T:
     with open(Path(__file__).parent / "data" / json_fname) as f:
         return model_cls.model_validate_json(f.read())
+
+
+def json_to_zarr_group(*, json_fname: str) -> zarr.Group:
+    """
+    Create an empty Zarr group, and set attributes from a JSON file.
+    """
+    group = zarr.open_group(store=zarr.MemoryStore())
+    with open(Path(__file__).parent / "data" / json_fname) as f:
+        attrs = json.load(f)
+
+    group.attrs.put(attrs)
+    return group
 
 
 def normalize_chunks(

--- a/tests/v04/data/image_label_example.json
+++ b/tests/v04/data/image_label_example.json
@@ -1,27 +1,67 @@
 {
-  "version": "0.4",
-  "colors": [
-    {
-      "label-value": 1,
-      "rgba": [255, 255, 255, 255]
-    },
-    {
-      "label-value": 4,
-      "rgba": [0, 255, 255, 128]
+  "image-label": {
+    "version": "0.4",
+    "colors": [
+      {
+        "label-value": 1,
+        "rgba": [255, 255, 255, 255]
+      },
+      {
+        "label-value": 4,
+        "rgba": [0, 255, 255, 128]
+      }
+    ],
+    "properties": [
+      {
+        "label-value": 1,
+        "area": 1200,
+        "cls": "foo"
+      },
+      {
+        "label-value": 4,
+        "area": 1650
+      }
+    ],
+    "source": {
+      "image": "../../"
     }
-  ],
-  "properties": [
+  },
+  "multiscales": [
     {
-      "label-value": 1,
-      "area": 1200,
-      "cls": "foo"
-    },
-    {
-      "label-value": 4,
-      "area": 1650
+      "version": "0.4",
+      "name": "example",
+      "axes": [
+        { "name": "t", "type": "time", "unit": "millisecond" },
+        { "name": "c", "type": "channel" },
+        { "name": "z", "type": "space", "unit": "micrometer" },
+        { "name": "y", "type": "space", "unit": "micrometer" },
+        { "name": "x", "type": "space", "unit": "micrometer" }
+      ],
+      "datasets": [
+        {
+          "path": "0",
+          "coordinateTransformations": [
+            {
+              "type": "scale",
+              "scale": [1.0, 1.0, 0.5, 0.5, 0.5]
+            }
+          ]
+        }
+      ],
+      "coordinateTransformations": [
+        {
+          "type": "scale",
+          "scale": [0.1, 1.0, 1.0, 1.0, 1.0]
+        }
+      ],
+      "type": "gaussian",
+      "metadata": {
+        "description": "abc",
+        "method": "skimage.transform.pyramid_gaussian",
+        "version": "0.16.1",
+        "args": "[true]",
+        "kwargs": { "multichannel": true }
+      }
     }
-  ],
-  "source": {
-    "image": "../../"
-  }
+  ]
 }


### PR DESCRIPTION
Previously we were just using `Image.from_zarr()`, which wasn't parsing or validating the `'image-labels'` metadata.