### PR TITLE
Remove dependency of `.common` sub-module on `.v04` submodule

### DIFF
--- a/src/ome_zarr_models/_v05/axes.py
+++ b/src/ome_zarr_models/_v05/axes.py
@@ -1,3 +1,3 @@
-from ome_zarr_models.v04.axes import Axes, Axis, AxisType
+from ome_zarr_models.common.axes import Axes, Axis, AxisType
 
 __all__ = ["Axes", "Axis", "AxisType"]

--- a/src/ome_zarr_models/common/axes.py
+++ b/src/ome_zarr_models/common/axes.py
@@ -1,0 +1,26 @@
+from collections.abc import Sequence
+from typing import Literal
+
+from pydantic import JsonValue
+
+from ome_zarr_models.base import BaseAttrs
+
+__all__ = ["Axes", "Axis", "AxisType"]
+
+
+AxisType = Literal["space", "time", "channel"]
+
+
+class Axis(BaseAttrs):
+    """
+    Model for an element of `Multiscale.axes`.
+
+    See https://ngff.openmicroscopy.org/0.4/#axes-md.
+    """
+
+    name: str
+    type: str | None = None
+    unit: str | JsonValue | None = None
+
+
+Axes = Sequence[Axis]

--- a/src/ome_zarr_models/common/coordinate_transformations.py
+++ b/src/ome_zarr_models/common/coordinate_transformations.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal, Self
+
+from pydantic import Field
+
+from ome_zarr_models.base import BaseAttrs
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+__all__ = [
+    "Identity",
+    "PathScale",
+    "PathTranslation",
+    "ScaleTransform",
+    "TranslationTransform",
+    "VectorScale",
+    "VectorTransform",
+    "VectorTranslation",
+]
+
+
+class Transform(BaseAttrs):
+    type: Literal["identity", "scale", "translation"]
+
+
+class Identity(Transform):
+    """
+    Identity transformation.
+
+    Notes
+    -----
+    Although defined in the specification, it is not allowed
+    to be used anywhere.
+    """
+
+    type: Literal["identity"]
+
+
+class VectorScale(Transform):
+    """
+    Scale transformation parametrized by a vector of numbers.
+    """
+
+    type: Literal["scale"]
+    scale: list[float]
+
+    @classmethod
+    def build(cls, data: Iterable[float]) -> Self:
+        """
+        Create a VectorScale from an iterable of floats.
+        """
+        return cls(type="scale", scale=list(data))
+
+    @property
+    def ndim(self) -> int:
+        """
+        Number of dimensions.
+        """
+        return len(self.scale)
+
+
+class PathScale(Transform):
+    """
+    Scale transformation parametrized by a path.
+    """
+
+    type: Literal["scale"]
+    path: str
+
+
+class VectorTranslation(Transform):
+    """
+    Translation transformation parametrized by a vector of numbers.
+    """
+
+    type: Literal["translation"] = Field(..., description="Type")
+    translation: list[float]
+
+    @classmethod
+    def build(cls, data: Iterable[float]) -> Self:
+        """
+        Create a VectorTranslation from an iterable of floats.
+        """
+        return cls(type="translation", translation=list(data))
+
+    @property
+    def ndim(self) -> int:
+        """
+        Number of dimensions.
+        """
+        return len(self.translation)
+
+
+class PathTranslation(Transform):
+    """
+    Translation transformation parametrized by a path.
+    """
+
+    type: Literal["translation"]
+    translation: str
+
+
+ScaleTransform = VectorScale | PathScale
+TranslationTransform = VectorTranslation | PathTranslation
+VectorTransform = VectorScale | VectorTranslation
+
+
+def _ndim(transform: VectorTransform) -> int:
+    """
+    Get the dimensionality of a scale or translation transform.
+    """
+    return transform.ndim
+
+
+def _build_transforms(
+    scale: Sequence[float], translation: Sequence[float] | None
+) -> tuple[VectorScale] | tuple[VectorScale, VectorTranslation]:
+    """
+    Create a `VectorScale` and optionally a `VectorTranslation` from a scale and a
+    translation parameter.
+    """
+    vec_scale = VectorScale.build(scale)
+    if translation is None:
+        return (vec_scale,)
+    else:
+        vec_trans = VectorTranslation.build(translation)
+        return vec_scale, vec_trans

--- a/src/ome_zarr_models/common/multiscales.py
+++ b/src/ome_zarr_models/common/multiscales.py
@@ -14,7 +14,7 @@ from pydantic import (
 
 from ome_zarr_models._utils import duplicates
 from ome_zarr_models.base import BaseAttrs
-from ome_zarr_models.v04.axes import Axes, AxisType
+from ome_zarr_models.common.axes import Axes, AxisType
 from ome_zarr_models.v04.coordinate_transformations import (
     ScaleTransform,
     Transform,

--- a/src/ome_zarr_models/common/multiscales.py
+++ b/src/ome_zarr_models/common/multiscales.py
@@ -15,7 +15,7 @@ from pydantic import (
 from ome_zarr_models._utils import duplicates
 from ome_zarr_models.base import BaseAttrs
 from ome_zarr_models.common.axes import Axes, AxisType
-from ome_zarr_models.v04.coordinate_transformations import (
+from ome_zarr_models.common.coordinate_transformations import (
     ScaleTransform,
     Transform,
     TranslationTransform,

--- a/src/ome_zarr_models/v04/axes.py
+++ b/src/ome_zarr_models/v04/axes.py
@@ -1,26 +1,3 @@
-from collections.abc import Sequence
-from typing import Literal
-
-from pydantic import JsonValue
-
-from ome_zarr_models.base import BaseAttrs
+from ome_zarr_models.common.axes import Axes, Axis, AxisType
 
 __all__ = ["Axes", "Axis", "AxisType"]
-
-
-AxisType = Literal["space", "time", "channel"]
-
-
-class Axis(BaseAttrs):
-    """
-    Model for an element of `Multiscale.axes`.
-
-    See https://ngff.openmicroscopy.org/0.4/#axes-md.
-    """
-
-    name: str
-    type: str | None = None
-    unit: str | JsonValue | None = None
-
-
-Axes = Sequence[Axis]

--- a/src/ome_zarr_models/v04/coordinate_transformations.py
+++ b/src/ome_zarr_models/v04/coordinate_transformations.py
@@ -2,16 +2,16 @@
 For reference, see the [coordinate transformations section of the OME-Zarr specification](https://ngff.openmicroscopy.org/0.4/#trafo-md).
 """
 
-from __future__ import annotations
-
-from typing import TYPE_CHECKING, Literal, Self
-
-from pydantic import Field
-
-from ome_zarr_models.base import BaseAttrs
-
-if TYPE_CHECKING:
-    from collections.abc import Iterable, Sequence
+from ome_zarr_models.common.coordinate_transformations import (
+    Identity,
+    PathScale,
+    PathTranslation,
+    ScaleTransform,
+    TranslationTransform,
+    VectorScale,
+    VectorTransform,
+    VectorTranslation,
+)
 
 __all__ = [
     "Identity",
@@ -23,111 +23,3 @@ __all__ = [
     "VectorTransform",
     "VectorTranslation",
 ]
-
-
-class Transform(BaseAttrs):
-    type: Literal["identity", "scale", "translation"]
-
-
-class Identity(Transform):
-    """
-    Identity transformation.
-
-    Notes
-    -----
-    Although defined in the specification, it is not allowed
-    to be used anywhere.
-    """
-
-    type: Literal["identity"]
-
-
-class VectorScale(Transform):
-    """
-    Scale transformation parametrized by a vector of numbers.
-    """
-
-    type: Literal["scale"]
-    scale: list[float]
-
-    @classmethod
-    def build(cls, data: Iterable[float]) -> Self:
-        """
-        Create a VectorScale from an iterable of floats.
-        """
-        return cls(type="scale", scale=list(data))
-
-    @property
-    def ndim(self) -> int:
-        """
-        Number of dimensions.
-        """
-        return len(self.scale)
-
-
-class PathScale(Transform):
-    """
-    Scale transformation parametrized by a path.
-    """
-
-    type: Literal["scale"]
-    path: str
-
-
-class VectorTranslation(Transform):
-    """
-    Translation transformation parametrized by a vector of numbers.
-    """
-
-    type: Literal["translation"] = Field(..., description="Type")
-    translation: list[float]
-
-    @classmethod
-    def build(cls, data: Iterable[float]) -> Self:
-        """
-        Create a VectorTranslation from an iterable of floats.
-        """
-        return cls(type="translation", translation=list(data))
-
-    @property
-    def ndim(self) -> int:
-        """
-        Number of dimensions.
-        """
-        return len(self.translation)
-
-
-class PathTranslation(Transform):
-    """
-    Translation transformation parametrized by a path.
-    """
-
-    type: Literal["translation"]
-    translation: str
-
-
-ScaleTransform = VectorScale | PathScale
-TranslationTransform = VectorTranslation | PathTranslation
-VectorTransform = VectorScale | VectorTranslation
-
-
-def _ndim(transform: VectorTransform) -> int:
-    """
-    Get the dimensionality of a scale or translation transform.
-    """
-    return transform.ndim
-
-
-def _build_transforms(
-    scale: Sequence[float], translation: Sequence[float] | None
-) -> tuple[VectorScale] | tuple[VectorScale, VectorTranslation]:
-    """
-    Create a `VectorScale` and optionally a `VectorTranslation` from a scale and a
-    translation parameter.
-    """
-    vec_scale = VectorScale.build(scale)
-    if translation is None:
-        return (vec_scale,)
-    else:
-        vec_trans = VectorTranslation.build(translation)
-        return vec_scale, vec_trans

--- a/tests/v04/test_multiscales.py
+++ b/tests/v04/test_multiscales.py
@@ -8,11 +8,13 @@ import pytest
 from pydantic import ValidationError
 from pydantic_zarr.v2 import ArraySpec, GroupSpec
 
+from ome_zarr_models.common.coordinate_transformations import (
+    _build_transforms,
+)
 from ome_zarr_models.v04.axes import Axis
 from ome_zarr_models.v04.coordinate_transformations import (
     VectorScale,
     VectorTranslation,
-    _build_transforms,
 )
 from ome_zarr_models.v04.image import Image, ImageAttrs
 from ome_zarr_models.v04.multiscales import (


### PR DESCRIPTION
It makes logical and structural sense that individual versions (v04, v05 etc.) depend on `.common`, not the other way around. This doesn't change any user-facing API (all the objects are re-exported in the v04) namespace.