### PR TITLE
Finish refactoring validators

### DIFF
--- a/src/ome_zarr_models/common/multiscales.py
+++ b/src/ome_zarr_models/common/multiscales.py
@@ -101,19 +101,6 @@ def _ensure_scale_translation(
     return transforms_obj
 
 
-def _ensure_axis_length(axes: Axes) -> Axes:
-    """
-    Ensures that there are between 2 and 5 axes (inclusive)
-    """
-    if (len_axes := len(axes)) not in VALID_NDIM:
-        msg = (
-            f"Incorrect number of axes provided ({len_axes}). "
-            "Only 2, 3, 4, or 5 axes are allowed."
-        )
-        raise ValueError(msg)
-    return axes
-
-
 class Dataset(BaseAttrs):
     """
     An element of Multiscale.datasets.
@@ -149,10 +136,7 @@ class MultiscaleBase(BaseAttrs):
     An element of multiscales metadata.
     """
 
-    axes: Annotated[
-        Axes,
-        AfterValidator(_ensure_axis_length),
-    ]
+    axes: Axes
     datasets: tuple[Dataset, ...] = Field(..., min_length=1)
     coordinateTransformations: ValidTransform | None = None
     metadata: JsonValue = None
@@ -242,6 +226,20 @@ class MultiscaleBase(BaseAttrs):
                 )
 
         return datasets
+
+    @field_validator("axes", mode="after")
+    @classmethod
+    def _ensure_axis_length(cls, axes: Axes) -> Axes:
+        """
+        Ensures that there are between 2 and 5 axes (inclusive)
+        """
+        if (len_axes := len(axes)) not in VALID_NDIM:
+            msg = (
+                f"Incorrect number of axes provided ({len_axes}). "
+                "Only 2, 3, 4, or 5 axes are allowed."
+            )
+            raise ValueError(msg)
+        return axes
 
     @field_validator("axes", mode="after")
     @classmethod

--- a/src/ome_zarr_models/common/multiscales.py
+++ b/src/ome_zarr_models/common/multiscales.py
@@ -114,20 +114,6 @@ def _ensure_axis_length(axes: Axes) -> Axes:
     return axes
 
 
-def _ensure_unique_axis_names(axes: Axes) -> Axes:
-    """
-    Ensures that the names of the axes are unique.
-    """
-    name_dupes = duplicates(a.name for a in axes)
-    if len(name_dupes) > 0:
-        msg = (
-            f"Axis names must be unique. Axis names {tuple(name_dupes.keys())} are "
-            "repeated."
-        )
-        raise ValueError(msg)
-    return axes
-
-
 class Dataset(BaseAttrs):
     """
     An element of Multiscale.datasets.
@@ -166,7 +152,6 @@ class MultiscaleBase(BaseAttrs):
     axes: Annotated[
         Axes,
         AfterValidator(_ensure_axis_length),
-        AfterValidator(_ensure_unique_axis_names),
     ]
     datasets: tuple[Dataset, ...] = Field(..., min_length=1)
     coordinateTransformations: ValidTransform | None = None
@@ -309,6 +294,21 @@ class MultiscaleBase(BaseAttrs):
             msg = (
                 f"Invalid number of custom axes: {num_custom}. "
                 "Only 1 custom axis is allowed."
+            )
+            raise ValueError(msg)
+        return axes
+
+    @field_validator("axes", mode="after")
+    @classmethod
+    def _ensure_unique_axis_names(cls, axes: Axes) -> Axes:
+        """
+        Ensures that the names of the axes are unique.
+        """
+        name_dupes = duplicates(a.name for a in axes)
+        if len(name_dupes) > 0:
+            msg = (
+                f"Axis names must be unique. Axis names {tuple(name_dupes.keys())} are "
+                "repeated."
             )
             raise ValueError(msg)
         return axes


### PR DESCRIPTION
This finishes a refactoring of validators to make them all methods on classes. This:

- means where validators are defined consistent (previously, we had a mix of methods and functions)
- makes the field listing a bit easier to read, by removing lots of `Annotated` definitions that include validators. Now there's just the data type defined, which I think makes it more readable

