### PR TITLE
Remove dependency of v05 on v04

### DIFF
--- a/src/ome_zarr_models/_v05/coordinate_transformations.py
+++ b/src/ome_zarr_models/_v05/coordinate_transformations.py
@@ -1,4 +1,4 @@
-from ome_zarr_models.v04.coordinate_transformations import (
+from ome_zarr_models.common.coordinate_transformations import (
     Identity,
     PathScale,
     PathTranslation,

--- a/src/ome_zarr_models/_v05/image_label_types.py
+++ b/src/ome_zarr_models/_v05/image_label_types.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from ome_zarr_models.v04.image_label_types import (
+from ome_zarr_models.common.image_label_types import (
     RGBA,
     Color,
     LabelBase,
@@ -9,13 +9,7 @@ from ome_zarr_models.v04.image_label_types import (
     Uint8,
 )
 
-__all__ = [
-    "RGBA",
-    "Color",
-    "Property",
-    "Source",
-    "Uint8",
-]
+__all__ = ["RGBA", "Color", "LabelBase", "Property", "Source", "Uint8"]
 
 
 class Label(LabelBase):

--- a/src/ome_zarr_models/_v05/well.py
+++ b/src/ome_zarr_models/_v05/well.py
@@ -1,15 +1,17 @@
 from pydantic_zarr.v2 import ArraySpec, GroupSpec
 
-import ome_zarr_models.v04.well
 from ome_zarr_models._v05.base import BaseGroupv05, BaseOMEAttrs, BaseZarrAttrs
+from ome_zarr_models.common.well_types import WellMeta
 
 __all__ = ["Well", "WellAttrs"]
 
 
-class WellAttrs(ome_zarr_models.v04.well.WellAttrs, BaseOMEAttrs):
+class WellAttrs(BaseOMEAttrs):
     """
     Attributes for a well.
     """
+
+    well: WellMeta
 
 
 class Well(GroupSpec[BaseZarrAttrs[WellAttrs], ArraySpec | GroupSpec], BaseGroupv05):  # type: ignore[misc]

--- a/src/ome_zarr_models/_v05/well_types.py
+++ b/src/ome_zarr_models/_v05/well_types.py
@@ -1,3 +1,3 @@
-from ome_zarr_models.v04.well_types import WellImage, WellMeta
+from ome_zarr_models.common.well_types import WellImage, WellMeta
 
 __all__ = ["WellImage", "WellMeta"]

--- a/src/ome_zarr_models/common/image_label_types.py
+++ b/src/ome_zarr_models/common/image_label_types.py
@@ -1,0 +1,110 @@
+"""
+For reference, see the [image label section of the OME-Zarr specification](https://ngff.openmicroscopy.org/0.4/index.html#label-md).
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal, Self
+
+from pydantic import Field, field_validator, model_validator
+
+from ome_zarr_models._utils import duplicates
+from ome_zarr_models.base import BaseAttrs
+
+__all__ = ["RGBA", "Color", "Label", "LabelBase", "Property", "Source", "Uint8"]
+
+Uint8 = Annotated[int, Field(strict=True, ge=0, le=255)]
+RGBA = tuple[Uint8, Uint8, Uint8, Uint8]
+
+
+class Color(BaseAttrs):
+    """
+    A label value and RGBA.
+    """
+
+    label_value: int = Field(..., alias="label-value")
+    rgba: RGBA | None
+
+
+class Source(BaseAttrs):
+    """
+    Source data for the labels.
+    """
+
+    # TODO: add validation that this path resolves to a zarr image group
+    image: str | None = Field(
+        default="../../", description="Relative path to a Zarr group of a key image."
+    )
+
+
+class Property(BaseAttrs):
+    """
+    A single property.
+    """
+
+    label_value: int = Field(..., alias="label-value")
+
+
+class LabelBase(BaseAttrs):
+    """
+    Base class for image-label metadata.
+    """
+
+    # TODO: validate
+    # "All the values under the label-value (of colors) key MUST be unique."
+    colors: tuple[Color, ...] | None = None
+    properties: tuple[Property, ...] | None = None
+    source: Source | None = None
+    version: str | None = None
+
+    @model_validator(mode="after")
+    def _check_label_values(self) -> Self:
+        """
+        Check that label_values are consistent across properties and colors
+        """
+        if self.colors is not None and self.properties is not None:
+            prop_label_value = [prop.label_value for prop in self.properties]
+            color_label_value = [color.label_value for color in self.colors]
+
+            prop_label_value_set = set(prop_label_value)
+            color_label_value_set = set(color_label_value)
+            if color_label_value_set != prop_label_value_set:
+                msg = (
+                    "Inconsistent `label_value` attributes in "
+                    "`colors` and `properties`."
+                    "The `properties` attributes have "
+                    f"`label_values` {prop_label_value}, "
+                    "The `colors` attributes have "
+                    f"`label_values` {color_label_value}, "
+                )
+                raise ValueError(msg)
+        return self
+
+    @field_validator("colors", mode="after")
+    def _parse_colors(cls, colors: tuple[Color, ...]) -> tuple[Color, ...]:
+        """
+        Check that color label values are unique.
+        """
+        # if colors is None:
+        #    msg = (
+        #        "The field `colors` is `None`. `colors` should be a list of "
+        #        "label descriptors."
+        #    )
+        #    warnings.warn(msg, stacklevel=1)
+        dupes = duplicates(x.label_value for x in colors)
+        if len(dupes) > 0:
+            msg = (
+                f"Duplicated label-value: {tuple(dupes.keys())}."
+                "label-values must be unique across elements of `colors`."
+            )
+            raise ValueError(msg)
+
+        return colors
+
+
+class Label(LabelBase):
+    """
+    Metadata for a single image-label.
+    """
+
+    version: Literal["0.4"] | None = None

--- a/src/ome_zarr_models/common/well.py
+++ b/src/ome_zarr_models/common/well.py
@@ -1,0 +1,10 @@
+from ome_zarr_models.base import BaseAttrs
+from ome_zarr_models.v04.well_types import WellMeta
+
+
+class WellAttrs(BaseAttrs):
+    """
+    Attributes for a well group.
+    """
+
+    well: WellMeta

--- a/src/ome_zarr_models/common/well_types.py
+++ b/src/ome_zarr_models/common/well_types.py
@@ -1,0 +1,63 @@
+"""
+For reference, see the [well section of the OME-Zarr specification](https://ngff.openmicroscopy.org/0.4/#well-md).
+"""
+
+from collections import defaultdict
+from typing import Annotated, Literal
+
+from pydantic import AfterValidator, Field
+
+from ome_zarr_models.base import BaseAttrs
+from ome_zarr_models.common.validation import (
+    AlphaNumericConstraint,
+    unique_items_validator,
+)
+
+__all__ = ["WellImage", "WellMeta"]
+
+
+class WellImage(BaseAttrs):
+    """
+    A single image within a well.
+    """
+
+    path: Annotated[str, AlphaNumericConstraint]
+    acquisition: int | None = Field(
+        None, description="A unique identifier within the context of the plate"
+    )
+
+
+class WellMeta(BaseAttrs):
+    """
+    Metadata for a single well.
+    """
+
+    images: Annotated[list[WellImage], AfterValidator(unique_items_validator)]
+    version: Literal["0.4"] | None = Field(
+        None, description="Version of the well specification"
+    )
+
+    def get_acquisition_paths(self) -> dict[int, list[str]]:
+        """
+        Get mapping from acquisition indices to corresponding paths.
+
+        Returns
+        -------
+        dict
+            Dictionary with `(acquisition index: [image_path])` key/value
+            pairs.
+
+        Raises
+        ------
+        ValueError
+            If an element of `self.well.images` has no `acquisition` attribute.
+        """
+        acquisition_dict: dict[int, list[str]] = defaultdict(list)
+        for image in self.images:
+            if image.acquisition is None:
+                raise ValueError(
+                    "Cannot get acquisition paths for Zarr files without "
+                    "'acquisition' metadata at the well level"
+                )
+            acquisition_dict[image.acquisition].append(image.path)
+        return dict(acquisition_dict)

--- a/src/ome_zarr_models/v04/image_label_types.py
+++ b/src/ome_zarr_models/v04/image_label_types.py
@@ -2,109 +2,14 @@
 For reference, see the [image label section of the OME-Zarr specification](https://ngff.openmicroscopy.org/0.4/index.html#label-md).
 """
 
-from __future__ import annotations
-
-from typing import Annotated, Literal, Self
-
-from pydantic import Field, field_validator, model_validator
-
-from ome_zarr_models._utils import duplicates
-from ome_zarr_models.base import BaseAttrs
+from ome_zarr_models.common.image_label_types import (
+    RGBA,
+    Color,
+    Label,
+    LabelBase,
+    Property,
+    Source,
+    Uint8,
+)
 
 __all__ = ["RGBA", "Color", "Label", "LabelBase", "Property", "Source", "Uint8"]
-
-Uint8 = Annotated[int, Field(strict=True, ge=0, le=255)]
-RGBA = tuple[Uint8, Uint8, Uint8, Uint8]
-
-
-class Color(BaseAttrs):
-    """
-    A label value and RGBA.
-    """
-
-    label_value: int = Field(..., alias="label-value")
-    rgba: RGBA | None
-
-
-class Source(BaseAttrs):
-    """
-    Source data for the labels.
-    """
-
-    # TODO: add validation that this path resolves to a zarr image group
-    image: str | None = Field(
-        default="../../", description="Relative path to a Zarr group of a key image."
-    )
-
-
-class Property(BaseAttrs):
-    """
-    A single property.
-    """
-
-    label_value: int = Field(..., alias="label-value")
-
-
-class LabelBase(BaseAttrs):
-    """
-    Base class for image-label metadata.
-    """
-
-    # TODO: validate
-    # "All the values under the label-value (of colors) key MUST be unique."
-    colors: tuple[Color, ...] | None = None
-    properties: tuple[Property, ...] | None = None
-    source: Source | None = None
-    version: str | None = None
-
-    @model_validator(mode="after")
-    def _check_label_values(self) -> Self:
-        """
-        Check that label_values are consistent across properties and colors
-        """
-        if self.colors is not None and self.properties is not None:
-            prop_label_value = [prop.label_value for prop in self.properties]
-            color_label_value = [color.label_value for color in self.colors]
-
-            prop_label_value_set = set(prop_label_value)
-            color_label_value_set = set(color_label_value)
-            if color_label_value_set != prop_label_value_set:
-                msg = (
-                    "Inconsistent `label_value` attributes in "
-                    "`colors` and `properties`."
-                    "The `properties` attributes have "
-                    f"`label_values` {prop_label_value}, "
-                    "The `colors` attributes have "
-                    f"`label_values` {color_label_value}, "
-                )
-                raise ValueError(msg)
-        return self
-
-    @field_validator("colors", mode="after")
-    def _parse_colors(cls, colors: tuple[Color, ...]) -> tuple[Color, ...]:
-        """
-        Check that color label values are unique.
-        """
-        # if colors is None:
-        #    msg = (
-        #        "The field `colors` is `None`. `colors` should be a list of "
-        #        "label descriptors."
-        #    )
-        #    warnings.warn(msg, stacklevel=1)
-        dupes = duplicates(x.label_value for x in colors)
-        if len(dupes) > 0:
-            msg = (
-                f"Duplicated label-value: {tuple(dupes.keys())}."
-                "label-values must be unique across elements of `colors`."
-            )
-            raise ValueError(msg)
-
-        return colors
-
-
-class Label(LabelBase):
-    """
-    Metadata for a single image-label.
-    """
-
-    version: Literal["0.4"] | None = None

--- a/src/ome_zarr_models/v04/well.py
+++ b/src/ome_zarr_models/v04/well.py
@@ -6,20 +6,11 @@ from collections.abc import Generator
 
 from pydantic_zarr.v2 import ArraySpec, GroupSpec
 
-from ome_zarr_models.base import BaseAttrs
+from ome_zarr_models.common.well import WellAttrs
 from ome_zarr_models.v04.base import BaseGroupv04
 from ome_zarr_models.v04.image import Image
-from ome_zarr_models.v04.well_types import WellMeta
 
 __all__ = ["Well", "WellAttrs"]
-
-
-class WellAttrs(BaseAttrs):
-    """
-    Attributes for a well group.
-    """
-
-    well: WellMeta
 
 
 class Well(GroupSpec[WellAttrs, ArraySpec | GroupSpec], BaseGroupv04):  # type: ignore[misc]

--- a/src/ome_zarr_models/v04/well_types.py
+++ b/src/ome_zarr_models/v04/well_types.py
@@ -2,62 +2,6 @@
 For reference, see the [well section of the OME-Zarr specification](https://ngff.openmicroscopy.org/0.4/#well-md).
 """
 
-from collections import defaultdict
-from typing import Annotated, Literal
-
-from pydantic import AfterValidator, Field
-
-from ome_zarr_models.base import BaseAttrs
-from ome_zarr_models.common.validation import (
-    AlphaNumericConstraint,
-    unique_items_validator,
-)
+from ome_zarr_models.common.well_types import WellImage, WellMeta
 
 __all__ = ["WellImage", "WellMeta"]
-
-
-class WellImage(BaseAttrs):
-    """
-    A single image within a well.
-    """
-
-    path: Annotated[str, AlphaNumericConstraint]
-    acquisition: int | None = Field(
-        None, description="A unique identifier within the context of the plate"
-    )
-
-
-class WellMeta(BaseAttrs):
-    """
-    Metadata for a single well.
-    """
-
-    images: Annotated[list[WellImage], AfterValidator(unique_items_validator)]
-    version: Literal["0.4"] | None = Field(
-        None, description="Version of the well specification"
-    )
-
-    def get_acquisition_paths(self) -> dict[int, list[str]]:
-        """
-        Get mapping from acquisition indices to corresponding paths.
-
-        Returns
-        -------
-        dict
-            Dictionary with `(acquisition index: [image_path])` key/value
-            pairs.
-
-        Raises
-        ------
-        ValueError
-            If an element of `self.well.images` has no `acquisition` attribute.
-        """
-        acquisition_dict: dict[int, list[str]] = defaultdict(list)
-        for image in self.images:
-            if image.acquisition is None:
-                raise ValueError(
-                    "Cannot get acquisition paths for Zarr files without "
-                    "'acquisition' metadata at the well level"
-                )
-            acquisition_dict[image.acquisition].append(image.path)
-        return dict(acquisition_dict)


### PR DESCRIPTION
This cleans up v05 so that it doesn't depend on v04 at all, and all shared code lives in `ome_zarr_models.common`.