### PR TITLE
Improve error message in open_ome_zarr()

### DIFF
--- a/src/ome_zarr_models/__init__.py
+++ b/src/ome_zarr_models/__init__.py
@@ -52,4 +52,10 @@ def open_ome_zarr(group: zarr.Group) -> BaseGroup[Any]:
         except ValidationError:
             continue
 
-    raise RuntimeError(f"Could not find any matches for group {group}")
+    raise RuntimeError(
+        f"Could not successfully validate {group} with any OME-Zarr group models.\n"
+        "\n"
+        "If you know what type of group you tryint to open, using the "
+        "<group class>.from_zarr() method will give you a more informative "
+        "error message explaining why validation failed."
+    )

--- a/src/ome_zarr_models/__init__.py
+++ b/src/ome_zarr_models/__init__.py
@@ -44,6 +44,11 @@ def open_ome_zarr(group: zarr.Group) -> BaseGroup[Any]:
     ----------
     group : zarr.Group
         Zarr group containing OME-Zarr data.
+
+    Raises
+    ------
+    RuntimeError :
+        If the passed group cannot be validated with any of the OME-Zarr group models.
     """
     group_cls: type[BaseGroupv04[Any]]
     for group_cls in _V04_groups:

--- a/src/ome_zarr_models/__init__.py
+++ b/src/ome_zarr_models/__init__.py
@@ -55,7 +55,7 @@ def open_ome_zarr(group: zarr.Group) -> BaseGroup[Any]:
     raise RuntimeError(
         f"Could not successfully validate {group} with any OME-Zarr group models.\n"
         "\n"
-        "If you know what type of group you tryint to open, using the "
+        "If you know what type of group you are trying to open, using the "
         "<group class>.from_zarr() method will give you a more informative "
         "error message explaining why validation failed."
     )

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import re
+from pathlib import Path
 
 import pytest
 import zarr

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import re
 
 import pytest
 import zarr
@@ -19,5 +20,11 @@ def test_load_ome_zarr_group() -> None:
 
 def test_load_ome_zarr_group_bad(tmp_path: Path) -> None:
     hcs_group = zarr.group(tmp_path / "test")
-    with pytest.raises(RuntimeError, match="Could not find any matches for group "):
+    with pytest.raises(
+        RuntimeError,
+        match=re.escape(
+            "Could not successfully validate <zarr.hierarchy.Group '/'> "
+            "with any OME-Zarr group models."
+        ),
+    ):
         open_ome_zarr(hcs_group)


### PR DESCRIPTION
See https://github.com/ome-zarr-models/ome-zarr-models-py/pull/167#issuecomment-2682298043. I don't think we have any way to propagate validation errors in this function (because we would have to propagate errors from *all* the OME-Zarr groups), but this improved error message at least explains the route to getting a more precise validation error message.

cc @will-moore