### PR TITLE
Add cross linking to Zarr docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ plugins:
             - https://docs.python.org/3/objects.inv
             - https://zarr.dev/pydantic-zarr/objects.inv
             - https://docs.pydantic.dev/latest/objects.inv
+            - https://zarr.readthedocs.io/en/v2.18.4/objects.inv
 
           options:
             docstring_style: numpy


### PR DESCRIPTION
I think linking to the latest v2 docs is the best we can do here? Ideally we would link to whatever the latest v2 release is, but I don't think that's possible...