### PR TITLE
Re-enable tutorial execution in docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,7 +34,7 @@ markdown_extensions:
 
 plugins:
   - mkdocs-jupyter:
-      execute: false
+      execute: true
       allow_errors: false
   - mkdocstrings:
       handlers:


### PR DESCRIPTION
This must have accidentally switched at some point 🙈 