### PR TITLE
Add .datasets property to Image

### DIFF
--- a/src/ome_zarr_models/v04/image.py
+++ b/src/ome_zarr_models/v04/image.py
@@ -221,15 +221,15 @@ class Image(BaseGroupv04[ImageAttrs]):
 
         return Labels(attributes=labels_group.attributes, members=labels_group.members)
 
-    def get_datasets(self, multiscales_idx: int = 0) -> tuple[Dataset, ...]:
+    @property
+    def datasets(self) -> tuple[tuple[Dataset, ...], ...]:
         """
-        Get Datasets stored in this Image.
+        Get datasets stored in this image.
 
-        By default the datasets from the first multiscale is returned.
-
-        Parameters
-        ----------
-        multiscales_idx :
-            Index of the multiscales array to get the datasets from.
+        The first index is for the multiscales.
+        The second index is for the dataset inside that multiscales.
         """
-        return self.attributes.multiscales[multiscales_idx].datasets
+        return tuple(
+            tuple(dataset for dataset in multiscale.datasets)
+            for multiscale in self.attributes.multiscales
+        )

--- a/src/ome_zarr_models/v04/image.py
+++ b/src/ome_zarr_models/v04/image.py
@@ -220,3 +220,16 @@ class Image(BaseGroupv04[ImageAttrs]):
         labels_group = self.members["labels"]
 
         return Labels(attributes=labels_group.attributes, members=labels_group.members)
+
+    def get_datasets(self, multiscales_idx: int = 0) -> tuple[Dataset, ...]:
+        """
+        Get Datasets stored in this Image.
+
+        By default the datasets from the first multiscale is returned.
+
+        Parameters
+        ----------
+        multiscales_idx :
+            Index of the multiscales array to get the datasets from.
+        """
+        return self.attributes.multiscales[multiscales_idx].datasets

--- a/tests/v04/test_image.py
+++ b/tests/v04/test_image.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from pydantic_zarr.v2 import ArraySpec
 
 from ome_zarr_models.common.coordinate_transformations import VectorTranslation
@@ -152,4 +153,45 @@ def test_new_image() -> None:
                 compressor=None,
             ),
         },
+    )
+
+
+@pytest.fixture
+def example_image() -> Image:
+    return Image.new(
+        array_specs=[
+            ArraySpec(shape=(5, 5), chunks=(2, 2), dtype=np.uint8),
+            ArraySpec(shape=(3, 3), chunks=(2, 2), dtype=np.uint8),
+        ],
+        paths=["scale0", "scale1"],
+        axes=[
+            Axis(name="x", type="space", unit="km"),
+            Axis(name="y", type="space", unit="km"),
+        ],
+        scales=[(4, 4), (8, 8)],
+        translations=[(2, 2), (4, 4)],
+        name="new_image_test",
+        multiscale_type="local mean",
+        metadata={"key": "val"},
+        global_scale=(-1, 1),
+        global_translation=(10, 10),
+    )
+
+
+def test_get_datasets(example_image: Image) -> None:
+    assert example_image.get_datasets() == (
+        Dataset(
+            path="scale0",
+            coordinateTransformations=(
+                VectorScale(type="scale", scale=[4.0, 4.0]),
+                VectorTranslation(type="translation", translation=[2.0, 2.0]),
+            ),
+        ),
+        Dataset(
+            path="scale1",
+            coordinateTransformations=(
+                VectorScale(type="scale", scale=[8.0, 8.0]),
+                VectorTranslation(type="translation", translation=[4.0, 4.0]),
+            ),
+        ),
     )

--- a/tests/v04/test_image.py
+++ b/tests/v04/test_image.py
@@ -178,20 +178,22 @@ def example_image() -> Image:
     )
 
 
-def test_get_datasets(example_image: Image) -> None:
-    assert example_image.get_datasets() == (
-        Dataset(
-            path="scale0",
-            coordinateTransformations=(
-                VectorScale(type="scale", scale=[4.0, 4.0]),
-                VectorTranslation(type="translation", translation=[2.0, 2.0]),
+def test_datasets(example_image: Image) -> None:
+    assert example_image.datasets == (
+        (
+            Dataset(
+                path="scale0",
+                coordinateTransformations=(
+                    VectorScale(type="scale", scale=[4.0, 4.0]),
+                    VectorTranslation(type="translation", translation=[2.0, 2.0]),
+                ),
             ),
-        ),
-        Dataset(
-            path="scale1",
-            coordinateTransformations=(
-                VectorScale(type="scale", scale=[8.0, 8.0]),
-                VectorTranslation(type="translation", translation=[4.0, 4.0]),
+            Dataset(
+                path="scale1",
+                coordinateTransformations=(
+                    VectorScale(type="scale", scale=[8.0, 8.0]),
+                    VectorTranslation(type="translation", translation=[4.0, 4.0]),
+                ),
             ),
         ),
     )


### PR DESCRIPTION
I'm not 100% sure this is a good idea, so feedback encouraged and requested.

To get the (e.g.,) first level of a multiscales, currently the syntax is
```python
ome_group[ome_zarr_image.attributes.multiscales[0].datasets[0].path]
```

this helper would shorten this to

```python
ome_group[ome_zarr_image.datasets[0][0].path]
```
