### PR TITLE
Allow HCS objects without existing well groups

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.10
+
+### Bug fixes
+
+- Creating a `HCS` group with well paths that do not point to existing well Zarr groups
+  no longer errors.
+
 ## 0.1.9
 
 ### Bug fixes

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,10 @@
 - Creating a `HCS` group with well paths that do not point to existing well Zarr groups
   no longer errors.
 
+### Breaking changes
+
+- `HCS.well_groups` will now only return well groups that exist, instead of erroring out if a well group is defined in the HCS metadata but does not exist as a Zarr group.
+
 ## 0.1.9
 
 ### Bug fixes

--- a/src/ome_zarr_models/common/well.py
+++ b/src/ome_zarr_models/common/well.py
@@ -8,3 +8,9 @@ class WellAttrs(BaseAttrs):
     """
 
     well: WellMeta
+
+
+class WellGroupNotFoundError(RuntimeError):
+    """
+    Raised if a well Zarr group is not found.
+    """

--- a/src/ome_zarr_models/v04/hcs.py
+++ b/src/ome_zarr_models/v04/hcs.py
@@ -4,6 +4,7 @@ from typing import Self
 from pydantic import model_validator
 
 from ome_zarr_models.base import BaseAttrs
+from ome_zarr_models.common.well import WellGroupNotFoundError
 from ome_zarr_models.v04.base import BaseGroupv04
 from ome_zarr_models.v04.plate import Plate
 from ome_zarr_models.v04.well import Well
@@ -60,9 +61,18 @@ class HCS(BaseGroupv04[HCSAttrs]):
     def well_groups(self) -> Generator[Well, None, None]:
         """
         Well groups within this HCS group.
+
+        Notes
+        -----
+        Only well groups that exist are returned. This can be less than the number
+        of wells defined in the HCS metadata if some of the well Zarr groups don't
+        exist.
         """
         for i in range(self.n_wells):
-            yield self.get_well_group(i)
+            try:
+                yield self.get_well_group(i)
+            except WellGroupNotFoundError:
+                continue
 
     def get_well_group(self, i: int) -> Well:
         """
@@ -72,12 +82,25 @@ class HCS(BaseGroupv04[HCSAttrs]):
         ----------
         i :
             Index of well group.
+
+        Raises
+        ------
+        WellGroupNotFoundError :
+            If no Zarr group is found at the well path.
         """
         well = self.attributes.plate.wells[i]
         well_path = well.path
         well_path_parts = well_path.split("/")
-        group = self
-        for part in well_path_parts:
-            group = group.members[part]
-
+        if len(well_path_parts) != 2:
+            raise RuntimeError(f"Well path '{well_path_parts}' does not have two parts")
+        row, col = well_path_parts
+        if row not in self.members:
+            raise WellGroupNotFoundError(
+                f"Row '{row}' not found in group members: {self.members}"
+            )
+        if col not in self.members[col]:
+            raise WellGroupNotFoundError(
+                f"Column '{col}' not found in row group members: {self.members[row]}"
+            )
+        group = self.members[row][col]
         return Well(attributes=group.attributes, members=group.members)

--- a/src/ome_zarr_models/v04/hcs.py
+++ b/src/ome_zarr_models/v04/hcs.py
@@ -98,7 +98,7 @@ class HCS(BaseGroupv04[HCSAttrs]):
             raise WellGroupNotFoundError(
                 f"Row '{row}' not found in group members: {self.members}"
             )
-        if col not in self.members[col]:
+        if col not in self.members[row]:
             raise WellGroupNotFoundError(
                 f"Column '{col}' not found in row group members: {self.members[row]}"
             )

--- a/src/ome_zarr_models/v04/hcs.py
+++ b/src/ome_zarr_models/v04/hcs.py
@@ -98,9 +98,9 @@ class HCS(BaseGroupv04[HCSAttrs]):
             raise WellGroupNotFoundError(
                 f"Row '{row}' not found in group members: {self.members}"
             )
-        if col not in self.members[row]:
+        if col not in self.members[row].members:
             raise WellGroupNotFoundError(
                 f"Column '{col}' not found in row group members: {self.members[row]}"
             )
-        group = self.members[row][col]
+        group = self.members[row].members[col]
         return Well(attributes=group.attributes, members=group.members)

--- a/tests/v04/test_hcs.py
+++ b/tests/v04/test_hcs.py
@@ -108,3 +108,25 @@ def test_example_hcs() -> None:
             version="0.4",
         ),
     )
+
+
+def test_non_existent_wells() -> None:
+    """
+    Make sure it's possible to create a HCS that has well paths that don't exist
+    as Zarr groups.
+
+    The relevant part of the OME-Zarr specification (https://ngff.openmicroscopy.org/0.4/index.html#plate-md)
+    does not specify explicitly that the Zarr groups have to exist.
+    """
+    HCS(
+        attributes={
+            "plate": {
+                "acquisitions": [{"id": 1}, {"id": 2}, {"id": 3}],
+                "columns": [{"name": "1"}],
+                "field_count": 10,
+                "rows": [{"name": "A"}],
+                "version": "0.4",
+                "wells": [{"columnIndex": 0, "path": "A/1", "rowIndex": 0}],
+            }
+        }
+    )

--- a/tests/v04/test_hcs.py
+++ b/tests/v04/test_hcs.py
@@ -14,7 +14,7 @@ from ome_zarr_models.v04.well_types import WellImage, WellMeta
 
 def test_example_hcs() -> None:
     group = zarr.open(Path(__file__).parent / "data" / "hcs_example.ome.zarr", mode="r")
-    hcs = HCS.from_zarr(group)
+    hcs: HCS = HCS.from_zarr(group)
     assert hcs.attributes == HCSAttrs(
         plate=Plate(
             acquisitions=[
@@ -38,7 +38,7 @@ def test_example_hcs() -> None:
 
     well_groups = list(hcs.well_groups)
     assert len(well_groups) == 1
-    well_group = well_groups[0]
+    well_group = hcs.get_well_group(0)
     assert well_group.attributes.well == WellMeta(
         images=[WellImage(path="0", acquisition=None)], version="0.4"
     )


### PR DESCRIPTION
The relevant part of the 0.4 specificaiton says:

> The plate dictionary MUST contain a wells key whose value MUST be a list of JSON objects defining the wells of the plate. Each well object MUST contain a path key whose value MUST be a string specifying the path to the well subgroup. The path MUST consist of a name in the rows list, a file separator (/), and a name from the columns list, in that order. The path MUST NOT contain additional leading or trailing directories. Each well object MUST contain both a rowIndex key whose value MUST be an integer identifying the index into the rows list and a columnIndex key whose value MUST be an integer identifying the index into the columns list. rowIndex and columnIndex MUST be 0-based. The rowIndex, columnIndex, and path MUST all refer to the same row/column pair.

There's no stipulation that the path exists or points to a valid Well Zarr group, so don't error out if some well groups don't exist.

cc @will-moore - can you take a look at this and let me know if it fixes your issue?

Fixes https://github.com/ome-zarr-models/ome-zarr-models-py/issues/211.