### PR TITLE
Remove depth keyword arguments

### DIFF
--- a/src/ome_zarr_models/v04/image.py
+++ b/src/ome_zarr_models/v04/image.py
@@ -42,7 +42,7 @@ class Image(BaseGroupv04[ImageAttrs]):
     """
 
     @classmethod
-    def from_zarr(cls, group: zarr.Group, *, depth: int = -1) -> Self:
+    def from_zarr(cls, group: zarr.Group) -> Self:  # type: ignore[override]
         """
         Create an OME-Zarr image model from a `zarr.Group`.
 
@@ -50,8 +50,6 @@ class Image(BaseGroupv04[ImageAttrs]):
         ----------
         group : zarr.Group
             A Zarr group that has valid OME-Zarr image metadata.
-        depth : int
-            Currently not used.
         """
         # on unlistable storage backends, the members of this group will be {}
         group_spec: AnyGroupSpec = GroupSpec.from_zarr(group, depth=0)

--- a/src/ome_zarr_models/v04/image_label.py
+++ b/src/ome_zarr_models/v04/image_label.py
@@ -27,7 +27,7 @@ class ImageLabel(BaseGroupv04[ImageLabelAttrs]):
     """
 
     @classmethod
-    def from_zarr(cls, group: zarr.Group, *, depth: int = -1) -> Self:
+    def from_zarr(cls, group: zarr.Group) -> Self:  # type: ignore[override]
         """
         Create an instance of an OME-Zarr image from a `zarr.Group`.
 
@@ -37,5 +37,5 @@ class ImageLabel(BaseGroupv04[ImageLabelAttrs]):
             A Zarr group that has valid OME-NGFF image label metadata.
         """
         # Use Image.from_zarr() to validate multiscale metadata
-        Image.from_zarr(group, depth=depth)
-        return super().from_zarr(group, depth=depth)
+        Image.from_zarr(group)
+        return super().from_zarr(group)

--- a/src/ome_zarr_models/v05/image.py
+++ b/src/ome_zarr_models/v05/image.py
@@ -36,7 +36,7 @@ class Image(BaseGroupv05[ImageAttrs]):
     """
 
     @classmethod
-    def from_zarr(cls, group: zarr.Group, *, depth: int = -1) -> Self:
+    def from_zarr(cls, group: zarr.Group) -> Self:  # type: ignore[override]
         """
         Create an OME-Zarr image model from a `zarr.Group`.
 

--- a/src/ome_zarr_models/v05/image_label.py
+++ b/src/ome_zarr_models/v05/image_label.py
@@ -28,7 +28,7 @@ class ImageLabel(
     """
 
     @classmethod
-    def from_zarr(cls, group: zarr.Group, *, depth: int = -1) -> Self:
+    def from_zarr(cls, group: zarr.Group) -> Self:  # type: ignore[override]
         """
         Create an instance of an OME-Zarr image from a `zarr.Group`.
 
@@ -38,5 +38,5 @@ class ImageLabel(
             A Zarr group that has valid OME-Zarr image label metadata.
         """
         # Use Image.from_zarr() to validate multiscale metadata
-        Image.from_zarr(group, depth=depth)
-        return super().from_zarr(group, depth=depth)
+        Image.from_zarr(group)
+        return super().from_zarr(group)

--- a/src/ome_zarr_models/v05/labels.py
+++ b/src/ome_zarr_models/v05/labels.py
@@ -84,7 +84,7 @@ class Labels(
     """
 
     @classmethod
-    def from_zarr(cls, group: zarr.Group, *, depth: int = -1) -> Self:
+    def from_zarr(cls, group: zarr.Group) -> Self:  # type: ignore[override]
         """
         Create an OME-Zarr labels model from a `zarr.Group`.
 
@@ -95,12 +95,12 @@ class Labels(
         """
         from ome_zarr_models.v05.image import Image
 
-        ret = super().from_zarr(group, depth=depth)
+        ret = super().from_zarr(group)
 
         # Check all labels paths are valid multiscales
         for label_path in ret.attributes.ome.labels:
             try:
-                Image.from_zarr(group[label_path], depth=depth)  # type: ignore[arg-type]
+                Image.from_zarr(group[label_path])  # type: ignore[arg-type]
             except Exception as err:
                 msg = (
                     f"Error validating the label path '{label_path}' "


### PR DESCRIPTION
Because we know the paths of all relevant OME-Zarr nodes from the metadata, the `depth` argument is redundant. This makes the signature of `from_zarr()` incompatible with `GroupSpec`, but I think that's okay.