### PR TITLE
Test on unlistable store

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Never
 
 import pytest
 from zarr.storage import LocalStore, MemoryStore
@@ -11,12 +11,33 @@ if TYPE_CHECKING:
     from zarr.abc.store import Store
 
 
-@pytest.fixture(params=["MemoryStore", "LocalStore"])
+class UnlistableStore(MemoryStore):
+    """
+    A memory store that doesn't support listing.
+
+    Mimics other remote stores (e.g., HTTP) that don't support listing.
+    """
+
+    supports_listing: bool = False
+
+    def list(self) -> Never:
+        raise NotImplementedError
+
+    def list_dir(self, prefix: str) -> Never:
+        raise NotImplementedError
+
+    def list_prefix(self, prefix: str) -> Never:
+        raise NotImplementedError
+
+
+@pytest.fixture(params=["MemoryStore", "LocalStore", "UnlistableStore"])
 def store(request: pytest.FixtureRequest, tmp_path: Path) -> Store:
     match request.param:
         case "MemoryStore":
             return MemoryStore()
         case "LocalStore":
             return LocalStore(root=tmp_path)
+        case "UnlistableStore":
+            return UnlistableStore()
         case _:
             raise RuntimeError(f"Unknown store class: {request.param}")

--- a/tests/v04/conftest.py
+++ b/tests/v04/conftest.py
@@ -4,6 +4,7 @@ from typing import TypeVar
 
 import zarr
 import zarr.storage
+from zarr.abc.store import Store
 
 from ome_zarr_models.base import BaseAttrs
 
@@ -18,11 +19,11 @@ def read_in_json(*, json_fname: str, model_cls: type[T]) -> T:
         return model_cls.model_validate_json(f.read())
 
 
-def json_to_zarr_group(*, json_fname: str) -> zarr.Group:
+def json_to_zarr_group(*, json_fname: str, store: Store) -> zarr.Group:
     """
     Create an empty Zarr group, and set the attributes from a JSON file.
     """
-    group = zarr.open_group(store=zarr.storage.MemoryStore(), zarr_format=2)
+    group = zarr.open_group(store=store, zarr_format=2)
     with open(Path(__file__).parent / "data" / json_fname) as f:
         attrs = json.load(f)
 

--- a/tests/v04/test_image.py
+++ b/tests/v04/test_image.py
@@ -3,6 +3,7 @@ import re
 import numpy as np
 import pytest
 from pydantic_zarr.v2 import ArraySpec
+from zarr.abc.store import Store
 
 from ome_zarr_models.common.coordinate_transformations import VectorTranslation
 from ome_zarr_models.v04.axes import Axis
@@ -12,8 +13,8 @@ from ome_zarr_models.v04.multiscales import Dataset, Multiscale
 from tests.v04.conftest import json_to_zarr_group
 
 
-def test_image() -> None:
-    zarr_group = json_to_zarr_group(json_fname="multiscales_example.json")
+def test_image(store: Store) -> None:
+    zarr_group = json_to_zarr_group(json_fname="multiscales_example.json", store=store)
     zarr_group.create_array(
         "0",
         shape=(1, 1, 1, 1),

--- a/tests/v04/test_image_label.py
+++ b/tests/v04/test_image_label.py
@@ -1,5 +1,6 @@
 import pytest
 from pydantic import ValidationError
+from zarr.abc.store import Store
 
 from ome_zarr_models.v04.axes import Axis
 from ome_zarr_models.v04.coordinate_transformations import VectorScale
@@ -11,11 +12,15 @@ from ome_zarr_models.v04.image_label_types import (
     Source,
 )
 from ome_zarr_models.v04.multiscales import Dataset, Multiscale
+from tests.conftest import UnlistableStore
 from tests.v04.conftest import json_to_zarr_group
 
 
-def test_image_label_example_json() -> None:
-    zarr_group = json_to_zarr_group(json_fname="image_label_example.json")
+def test_image_label_example_json(store: Store) -> None:
+    if isinstance(store, UnlistableStore):
+        pytest.xfail("ImageLabel does not work on unlistable stores")
+
+    zarr_group = json_to_zarr_group(json_fname="image_label_example.json", store=store)
     zarr_group.create_array("0", shape=(1, 1, 1, 1, 1), dtype="uint8")
     ome_group = ImageLabel.from_zarr(zarr_group)
 

--- a/tests/v04/test_labels.py
+++ b/tests/v04/test_labels.py
@@ -1,10 +1,17 @@
+import pytest
+from zarr.abc.store import Store
+
 from ome_zarr_models.v04.image import Image
 from ome_zarr_models.v04.labels import LabelsAttrs
+from tests.conftest import UnlistableStore
 from tests.v04.conftest import json_to_zarr_group
 
 
-def test_image_with_labels() -> None:
-    zarr_group = json_to_zarr_group(json_fname="multiscales_example.json")
+def test_image_with_labels(store: Store) -> None:
+    if isinstance(store, UnlistableStore):
+        pytest.xfail("Labels do not work on unlistable stores")
+
+    zarr_group = json_to_zarr_group(json_fname="multiscales_example.json", store=store)
     zarr_group.create_group("labels")
     zarr_group["labels"].create_array("labels0", shape=(1, 1), dtype="uint8")  # type: ignore[union-attr]
     zarr_group["labels"].attrs.put({"labels": ["labels0"]})

--- a/tests/v04/test_well.py
+++ b/tests/v04/test_well.py
@@ -1,10 +1,16 @@
+import pytest
+from zarr.abc.store import Store
+
 from ome_zarr_models.v04.well import Well, WellAttrs
 from ome_zarr_models.v04.well_types import WellImage, WellMeta
+from tests.conftest import UnlistableStore
 from tests.v04.conftest import json_to_zarr_group
 
 
-def test_well() -> None:
-    zarr_group = json_to_zarr_group(json_fname="well_example_1.json")
+def test_well(store: Store) -> None:
+    if isinstance(store, UnlistableStore):
+        pytest.xfail("ImageLabel does not work on unlistable stores")
+    zarr_group = json_to_zarr_group(json_fname="well_example_1.json", store=store)
     ome_group = Well.from_zarr(zarr_group)
     assert ome_group.attributes == WellAttrs(
         well=WellMeta(
@@ -18,7 +24,7 @@ def test_well() -> None:
         )
     )
 
-    zarr_group = json_to_zarr_group(json_fname="well_example_2.json")
+    zarr_group = json_to_zarr_group(json_fname="well_example_2.json", store=store)
     ome_group = Well.from_zarr(zarr_group)
     assert ome_group.attributes == WellAttrs(
         well=WellMeta(

--- a/tests/v05/conftest.py
+++ b/tests/v05/conftest.py
@@ -4,6 +4,7 @@ from typing import TypeVar
 
 import zarr
 import zarr.storage
+from zarr.abc.store import Store
 
 from ome_zarr_models.base import BaseAttrs
 
@@ -18,11 +19,11 @@ def read_in_json(*, json_fname: str, model_cls: type[T]) -> T:
         return model_cls.model_validate_json(f.read())
 
 
-def json_to_zarr_group(*, json_fname: str) -> zarr.Group:
+def json_to_zarr_group(*, json_fname: str, store: Store) -> zarr.Group:
     """
     Create an empty Zarr group, and set attributes from a JSON file.
     """
-    group = zarr.open_group(store=zarr.storage.MemoryStore(), zarr_format=3)
+    group = zarr.open_group(store=store, zarr_format=3)
     with open(Path(__file__).parent / "data" / json_fname) as f:
         attrs = json.load(f)
 

--- a/tests/v05/test_general.py
+++ b/tests/v05/test_general.py
@@ -7,13 +7,19 @@ import re
 import numpy as np
 import pytest
 from pydantic import ValidationError
+from zarr.abc.store import Store
 
 from ome_zarr_models.v05.labels import Labels
+from tests.conftest import UnlistableStore
 from tests.v05.conftest import json_to_zarr_group
 
 
-def test_no_ome_version_fails() -> None:
-    zarr_group = json_to_zarr_group(json_fname="labels_no_version_example.json")
+def test_no_ome_version_fails(store: Store) -> None:
+    if isinstance(store, UnlistableStore):
+        pytest.xfail("Labels does not work on unlistable stores")
+    zarr_group = json_to_zarr_group(
+        json_fname="labels_no_version_example.json", store=store
+    )
     zarr_group.create_array("cell_space_segmentation", shape=(1, 1), dtype=np.int64)
     with pytest.raises(ValidationError, match=re.escape("attributes.ome.version")):
         Labels.from_zarr(zarr_group)

--- a/tests/v05/test_hcs.py
+++ b/tests/v05/test_hcs.py
@@ -1,10 +1,16 @@
+import pytest
+from zarr.abc.store import Store
+
 from ome_zarr_models.v05.hcs import HCS, HCSAttrs
 from ome_zarr_models.v05.plate import Acquisition, Column, Plate, Row, WellInPlate
+from tests.conftest import UnlistableStore
 from tests.v05.conftest import json_to_zarr_group
 
 
-def test_hcs() -> None:
-    zarr_group = json_to_zarr_group(json_fname="hcs_example.json")
+def test_hcs(store: Store) -> None:
+    if isinstance(store, UnlistableStore):
+        pytest.xfail("HCS does not work on unlistable stores")
+    zarr_group = json_to_zarr_group(json_fname="hcs_example.json", store=store)
     ome_group = HCS.from_zarr(zarr_group)
     assert ome_group.attributes.ome == HCSAttrs(
         plate=Plate(

--- a/tests/v05/test_image.py
+++ b/tests/v05/test_image.py
@@ -1,3 +1,5 @@
+from zarr.abc.store import Store
+
 from ome_zarr_models.v05.axes import Axis
 from ome_zarr_models.v05.coordinate_transformations import VectorScale
 from ome_zarr_models.v05.image import Image, ImageAttrs
@@ -5,8 +7,8 @@ from ome_zarr_models.v05.multiscales import Dataset, Multiscale
 from tests.v05.conftest import json_to_zarr_group
 
 
-def test_image() -> None:
-    zarr_group = json_to_zarr_group(json_fname="image_example.json")
+def test_image(store: Store) -> None:
+    zarr_group = json_to_zarr_group(json_fname="image_example.json", store=store)
     zarr_group.create_array(
         "0",
         shape=(1, 1, 1, 1, 1),

--- a/tests/v05/test_image_label.py
+++ b/tests/v05/test_image_label.py
@@ -1,13 +1,19 @@
+import pytest
+from zarr.abc.store import Store
+
 from ome_zarr_models.v05.axes import Axis
 from ome_zarr_models.v05.coordinate_transformations import VectorScale
 from ome_zarr_models.v05.image_label import ImageLabel, ImageLabelAttrs
 from ome_zarr_models.v05.image_label_types import Color, Label, Source
 from ome_zarr_models.v05.multiscales import Dataset, Multiscale
+from tests.conftest import UnlistableStore
 from tests.v05.conftest import json_to_zarr_group
 
 
-def test_image_label() -> None:
-    zarr_group = json_to_zarr_group(json_fname="image_label_example.json")
+def test_image_label(store: Store) -> None:
+    if isinstance(store, UnlistableStore):
+        pytest.xfail("ImageLabel does not work on unlistable stores")
+    zarr_group = json_to_zarr_group(json_fname="image_label_example.json", store=store)
     zarr_group.create_array("0", shape=(1, 1, 1, 1, 1), dtype="uint8")
     zarr_group.create_array("1", shape=(1, 1, 1, 1, 1), dtype="uint8")
     zarr_group.create_array("2", shape=(1, 1, 1, 1, 1), dtype="uint8")

--- a/tests/v05/test_plate.py
+++ b/tests/v05/test_plate.py
@@ -2,14 +2,20 @@ import re
 
 import pytest
 from pydantic import ValidationError
+from zarr.abc.store import Store
 
 from ome_zarr_models.v05.hcs import HCS
 from ome_zarr_models.v05.plate import Acquisition, Column, Plate, Row, WellInPlate
+from tests.conftest import UnlistableStore
 from tests.v05.conftest import json_to_zarr_group
 
 
-def test_example_plate_json() -> None:
-    hcs: HCS = HCS.from_zarr(json_to_zarr_group(json_fname="plate_example_1.json"))
+def test_example_plate_json(store: Store) -> None:
+    if isinstance(store, UnlistableStore):
+        pytest.xfail("HCS does not work on unlistable stores")
+    hcs: HCS = HCS.from_zarr(
+        json_to_zarr_group(json_fname="plate_example_1.json", store=store)
+    )
     plate = hcs.ome_attributes.plate
     assert plate == Plate(
         acquisitions=[
@@ -46,8 +52,12 @@ def test_example_plate_json() -> None:
     )
 
 
-def test_example_plate_json_2() -> None:
-    hcs: HCS = HCS.from_zarr(json_to_zarr_group(json_fname="plate_example_2.json"))
+def test_example_plate_json_2(store: Store) -> None:
+    if isinstance(store, UnlistableStore):
+        pytest.xfail("HCS does not work on unlistable stores")
+    hcs: HCS = HCS.from_zarr(
+        json_to_zarr_group(json_fname="plate_example_2.json", store=store)
+    )
     plate = hcs.ome_attributes.plate
     assert plate == Plate(
         acquisitions=[

--- a/tests/v05/test_well.py
+++ b/tests/v05/test_well.py
@@ -1,10 +1,16 @@
+import pytest
+from zarr.abc.store import Store
+
 from ome_zarr_models.v05.well import Well, WellAttrs
 from ome_zarr_models.v05.well_types import WellImage, WellMeta
+from tests.conftest import UnlistableStore
 from tests.v05.conftest import json_to_zarr_group
 
 
-def test_well() -> None:
-    zarr_group = json_to_zarr_group(json_fname="well_example.json")
+def test_well(store: Store) -> None:
+    if isinstance(store, UnlistableStore):
+        pytest.xfail("Well does not work on unlistable stores")
+    zarr_group = json_to_zarr_group(json_fname="well_example.json", store=store)
     ome_group = Well.from_zarr(zarr_group)
     assert ome_group.attributes.ome == WellAttrs(
         version="0.5",


### PR DESCRIPTION
This is progress towards https://github.com/ome-zarr-models/ome-zarr-models-py/issues/225, by adding testing on an unlistable Store. Many of the OME-Zarr groups currently fail the tests, so post this PR the work to do is add support from unlistable stores.