### PR TITLE
Support unlistable stores on v04 ImageLabel

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 1.0.0
+## 1.1
+
+### New Features
+
+- [ome_zarr_models.v04.ImageLabel][] now supports being created from a Zarr array backed by an un-listable store.
+
+## 1.0
 
 ### New Features
 

--- a/src/ome_zarr_models/v04/image_label.py
+++ b/src/ome_zarr_models/v04/image_label.py
@@ -34,8 +34,8 @@ class ImageLabel(BaseGroupv04[ImageLabelAttrs]):
         Parameters
         ----------
         group : zarr.Group
-            A Zarr group that has valid OME-NGFF image label metadata.
+            A Zarr group that has valid OME-Zarr image label metadata.
         """
         # Use Image.from_zarr() to validate multiscale metadata
-        Image.from_zarr(group)
-        return super().from_zarr(group)
+        image = Image.from_zarr(group)
+        return cls(attributes=image.attributes.model_dump(), members=image.members)

--- a/tests/v04/test_image_label.py
+++ b/tests/v04/test_image_label.py
@@ -12,14 +12,10 @@ from ome_zarr_models.v04.image_label_types import (
     Source,
 )
 from ome_zarr_models.v04.multiscales import Dataset, Multiscale
-from tests.conftest import UnlistableStore
 from tests.v04.conftest import json_to_zarr_group
 
 
 def test_image_label_example_json(store: Store) -> None:
-    if isinstance(store, UnlistableStore):
-        pytest.xfail("ImageLabel does not work on unlistable stores")
-
     zarr_group = json_to_zarr_group(json_fname="image_label_example.json", store=store)
     zarr_group.create_array("0", shape=(1, 1, 1, 1, 1), dtype="uint8")
     ome_group = ImageLabel.from_zarr(zarr_group)
@@ -69,6 +65,7 @@ def test_image_label_example_json(store: Store) -> None:
                 type="gaussian",
             )
         ],
+        omero=None,
     )
 
 


### PR DESCRIPTION
Part of https://github.com/ome-zarr-models/ome-zarr-models-py/issues/225. This was already supported on v05 ImageLabel, so this just copies across the logic.