### PR TITLE
Move v04 WellAttrs out of common module

### DIFF
--- a/src/ome_zarr_models/common/well.py
+++ b/src/ome_zarr_models/common/well.py
@@ -1,15 +1,3 @@
-from ome_zarr_models.base import BaseAttrs
-from ome_zarr_models.v04.well_types import WellMeta
-
-
-class WellAttrs(BaseAttrs):
-    """
-    Attributes for a well group.
-    """
-
-    well: WellMeta
-
-
 class WellGroupNotFoundError(RuntimeError):
     """
     Raised if a well Zarr group is not found.

--- a/src/ome_zarr_models/v04/well.py
+++ b/src/ome_zarr_models/v04/well.py
@@ -5,15 +5,24 @@ For reference, see the [well section of the OME-Zarr specification](https://ngff
 from collections.abc import Generator
 from typing import TYPE_CHECKING
 
-from ome_zarr_models.common.well import WellAttrs
+from ome_zarr_models.base import BaseAttrs
 from ome_zarr_models.v04.base import BaseGroupv04
 from ome_zarr_models.v04.image import Image
+from ome_zarr_models.v04.well_types import WellMeta
 
 if TYPE_CHECKING:
     from pydantic_zarr.v2 import AnyGroupSpec
 
 
 __all__ = ["Well", "WellAttrs"]
+
+
+class WellAttrs(BaseAttrs):
+    """
+    Attributes for a well group.
+    """
+
+    well: WellMeta
 
 
 class Well(BaseGroupv04[WellAttrs]):


### PR DESCRIPTION
This avoids the v04 import in `common`. Other versions have their own copies of `WellAttrs` defined anyway, so it makes sense to move this back to `v04`.