### PR TITLE
Add search plugin for docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ markdown_extensions:
   - pymdownx.superfences
 
 plugins:
+  - search
   - mkdocs-jupyter:
       execute: true
       allow_errors: false


### PR DESCRIPTION
This pull requests adds search functionality to the docs.  The default search plugin has to be added back in if other plugins are added - see [reference](https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/#built-in-search-plugin).

cc @satra