### PR TITLE
Add GitHub Actions workflow to publish documentation

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,48 @@
+name: Publish docs via GitHub Pages
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Publish docs
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+      
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install requirements
+        run: pip install .[docs]
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Build documentation
+        run: mkdocs build -f mkdocs.yml
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Hi @dstansby, not sure how you are deploying the docs, but I am submitting a GitHub Actions workflow to automatically publish to GitHub Pages upon merge to `main`.  Here is a preview deployed from my fork: https://kabilar.github.io/ome-zarr-models-py/.  You will need to enable GitHub Pages in the Settings:
<img width="1307" height="654" alt="image" src="https://github.com/user-attachments/assets/fbd51182-a11e-4bf6-88e0-7acb885b1bfa" />




Feel free to use this pull request or close.

cc @satra