### PR TITLE
fix: Make name required in axes for version 0.4 and 0.5

### DIFF
--- a/src/ome_zarr_models/_v06/axes.py
+++ b/src/ome_zarr_models/_v06/axes.py
@@ -16,10 +16,7 @@ class Axis(BaseAttrs):
     Model for an element of `Multiscale.axes`.
     """
 
-    # Explicitly name could be any JsonValue, but implicitly it must match Zarr array
-    # dimension_names which limits it to str | None
-
-    name: str | None
+    name: str
     type: str | None = None
     # Unit probably intended to be str, but the spec doesn't explicitly specify
     unit: str | JsonValue | None = None

--- a/src/ome_zarr_models/v05/axes.py
+++ b/src/ome_zarr_models/v05/axes.py
@@ -16,10 +16,7 @@ class Axis(BaseAttrs):
     Model for an element of `Multiscale.axes`.
     """
 
-    # Explicitly name could be any JsonValue, but implicitly it must match Zarr array
-    # dimension_names which limits it to str | None
-
-    name: str | None
+    name: str
     type: str | None = None
     # Unit probably intended to be str, but the spec doesn't explicitly specify
     unit: str | JsonValue | None = None


### PR DESCRIPTION
Follow up to #295