### PR TITLE
Use AnyTransform for compound transform type

### DIFF
--- a/src/ome_zarr_models/_v06/coordinate_transforms.py
+++ b/src/ome_zarr_models/_v06/coordinate_transforms.py
@@ -144,7 +144,7 @@ class Sequence(Transform):
     """Sequence transformation."""
 
     type: Literal["sequence"] = "sequence"
-    transformations: tuple[Transform, ...]
+    transformations: tuple["AnyTransform", ...]
 
 
 class Displacements(Transform):
@@ -167,7 +167,7 @@ class Inverse(Transform):
     """Inverse transform."""
 
     type: Literal["inverseOf"] = "inverseOf"
-    transform: Transform
+    transform: "AnyTransform"
 
 
 class Bijection(Transform):
@@ -176,8 +176,8 @@ class Bijection(Transform):
     """
 
     type: Literal["bijection"] = "bijection"
-    forward: Transform
-    inverse: Transform
+    forward: "AnyTransform"
+    inverse: "AnyTransform"
 
 
 AnyTransform = (

--- a/tests/_v06/rfc5/transform_examples/failing_zarrs.txt
+++ b/tests/_v06/rfc5/transform_examples/failing_zarrs.txt
@@ -2,7 +2,6 @@
 2d/axis_dependent/mapAxis.zarr
 2d/basic/identity.zarr
 2d/basic/scale_multiscale.zarr
-2d/basic/sequenceScaleTranslation.zarr
 2d/basic/sequenceScaleTranslation_multiscale.zarr
 2d/basic/translation.zarr
 2d/basic_binary/scaleParams.zarr
@@ -18,7 +17,6 @@
 3d/axis_dependent/mapAxis.zarr
 3d/basic/identity.zarr
 3d/basic/scale_multiscale.zarr
-3d/basic/sequenceScaleTranslation.zarr
 3d/basic/sequenceScaleTranslation_multiscale.zarr
 3d/basic/translation.zarr
 3d/basic_binary/scaleParams.zarr


### PR DESCRIPTION
This allows concrete transform types to be inferred when `pydantic` is parsing JSON.