### PR TITLE
Add default coordinate system properties for multiscales

### DIFF
--- a/src/ome_zarr_models/_v06/multiscales.py
+++ b/src/ome_zarr_models/_v06/multiscales.py
@@ -48,28 +48,36 @@ class Multiscale(BaseAttrs):
     def ndim(self) -> int:
         """
         Dimensionality of the data described by this metadata.
-
-        Determined by the number of dimensions of the output coordinate system.
         """
-        output_cs_name = self.datasets[0].coordinateTransformations[0].output
-        for cs in self.coordinateSystems:
-            if cs.name == output_cs_name:
-                return cs.ndim
-
-        raise RuntimeError(
-            f"Did not find coordinate system named '{output_cs_name}' in "
-            "multiscales coordinate systems."
-        )
+        return self.intrinsic_coordinate_system.ndim
 
     @property
     def default_coordinate_system(self) -> CoordinateSystem:
         """
-        Property returning the default coordinate system (i.e. the first entry).
+        The default coordinate system for this multiscales.
 
-        The default coordinate system should be used for viewing and processing unless
-        a use case dictates otherwise
+        Any references to this multiscales in coordinate transformations will resolve
+        to this coordinate system.
+
+        Notes
+        -----
+        This is the first entry in the `coordinateSystems` attribute.
         """
         return self.coordinateSystems[0]
+
+    @property
+    def intrinsic_coordinate_system(self) -> CoordinateSystem:
+        """
+        Physical coordinate system.
+
+        Should be used for viewing and processing unless a use case dictates otherwise.
+        A representation of the image in its native physical coordinate system.
+
+        Notes
+        -----
+        This is the last entry in the `coordinateSystems` attribute.
+        """
+        return self.coordinateSystems[-1]
 
     @model_validator(mode="after")
     def _ensure_same_output_cs_for_all_datasets(data: Self) -> Self:

--- a/tests/_v06/test_multiscales.py
+++ b/tests/_v06/test_multiscales.py
@@ -240,3 +240,51 @@ def test_ensure_ordered_scales() -> None:
                 ),
             ),
         )
+
+
+def test_default_coordinate_systems() -> None:
+    multiscale = Multiscale(
+        coordinateTransformations=None,
+        coordinateSystems=(
+            CoordinateSystem(
+                name="an_other_system",
+                axes=[
+                    Axis(name="x"),
+                    Axis(name="y"),
+                ],
+            ),
+            CoordinateSystem(
+                name="physical",
+                axes=[
+                    Axis(name="j"),
+                    Axis(name="i"),
+                ],
+            ),
+        ),
+        datasets=(
+            Dataset(
+                path="0",
+                coordinateTransformations=(
+                    Scale(
+                        scale=[2.0, 2.0],
+                        input="0",
+                        output="out",
+                    ),
+                ),
+            ),
+        ),
+    )
+    assert multiscale.intrinsic_coordinate_system == CoordinateSystem(
+        name="physical",
+        axes=(
+            Axis(name="j", type=None, discrete=None, unit=None, longName=None),
+            Axis(name="i", type=None, discrete=None, unit=None, longName=None),
+        ),
+    )
+    assert multiscale.default_coordinate_system == CoordinateSystem(
+        name="an_other_system",
+        axes=(
+            Axis(name="x", type=None, discrete=None, unit=None, longName=None),
+            Axis(name="y", type=None, discrete=None, unit=None, longName=None),
+        ),
+    )


### PR DESCRIPTION
This adds properties for the default coordinate systems now specified by RFC5. It also now takes the dimensionality of the multiscales from the intrinsic coordinate system.