### PR TITLE
Validate input of transforms in multiscale datasests

### DIFF
--- a/src/ome_zarr_models/_v06/multiscales.py
+++ b/src/ome_zarr_models/_v06/multiscales.py
@@ -390,6 +390,16 @@ class Dataset(BaseAttrs):
             coordinateTransformations=(transform,),
         )
 
+    @model_validator(mode="after")
+    def check_cs_input(self) -> Self:
+        for transformation in self.coordinateTransformations:
+            if transformation.input != self.path:
+                raise ValueError(
+                    "Input for a dataset transform must be the dataset array path: "
+                    f"'{self.path}'. Got '{transformation.input}' instead."
+                )
+        return self
+
     @field_validator("coordinateTransformations", mode="after")
     @classmethod
     def _ensure_transform_dimensionality(

--- a/tests/_v06/test_image_label.py
+++ b/tests/_v06/test_image_label.py
@@ -81,7 +81,7 @@ def test_image_label(store: Store) -> None:
                         coordinateTransformations=[
                             Scale(
                                 type="scale",
-                                input="/0",
+                                input="0",
                                 output="coord_sys0",
                                 name=None,
                                 scale=[1.0, 1.0, 0.5, 0.5, 0.5],
@@ -93,7 +93,7 @@ def test_image_label(store: Store) -> None:
                         coordinateTransformations=[
                             Scale(
                                 type="scale",
-                                input="/1",
+                                input="1",
                                 output="coord_sys0",
                                 name=None,
                                 scale=[1.0, 1.0, 1.0, 1.0, 1.0],
@@ -105,7 +105,7 @@ def test_image_label(store: Store) -> None:
                         coordinateTransformations=[
                             Scale(
                                 type="scale",
-                                input="/2",
+                                input="2",
                                 output="coord_sys0",
                                 name=None,
                                 scale=[1.0, 1.0, 2.0, 2.0, 2.0],

--- a/tests/_v06/test_multiscales.py
+++ b/tests/_v06/test_multiscales.py
@@ -55,7 +55,7 @@ def test_ensure_scale_translation() -> None:
         coordinateTransformations=(
             Scale(
                 scale=[1.0, 1.0],
-                input="/0",
+                input="0",
                 output=COORDINATE_SYSTEM_NAME_FOR_TESTS,
             ),
         )
@@ -73,7 +73,7 @@ def test_ensure_scale_translation() -> None:
             coordinateTransformations=(
                 Translation(
                     translation=[1.0, 1.0],
-                    input="/0",
+                    input="0",
                     output=COORDINATE_SYSTEM_NAME_FOR_TESTS,
                 ),
             )
@@ -89,7 +89,7 @@ def test_ensure_scale_translation() -> None:
             coordinateTransformations=(
                 Translation(
                     translation=[1.0, 1.0],
-                    input="/0",
+                    input="0",
                     output="intermediate",  # can be anything, this case is not
                     # valid anyway
                 ),
@@ -117,7 +117,7 @@ def test_ensure_scale_translation() -> None:
                         output=None,
                     ),
                 ),
-                input="/0",
+                input="0",
                 output=COORDINATE_SYSTEM_NAME_FOR_TESTS,
             ),
         )
@@ -131,7 +131,7 @@ def test_ensure_scale_translation() -> None:
         _ = _gen_multiscale(
             coordinateTransformations=(
                 Sequence(
-                    input="/0",
+                    input="0",
                     output=COORDINATE_SYSTEM_NAME_FOR_TESTS,
                     transformations=[
                         Scale(scale=[1.0, 1.0], input=None, output=None),
@@ -172,7 +172,7 @@ def test_invalid_dimensionalities() -> None:
                     coordinateTransformations=(
                         Scale(
                             scale=[1.0, 1.0, 1.0],
-                            input="/0",
+                            input="0",
                             output="out",
                         ),
                     ),
@@ -193,7 +193,7 @@ def test_invalid_dimensionalities() -> None:
                                     output=None,
                                 ),
                             ),
-                            input="/1",
+                            input="1",
                             output="out",
                         ),
                     ),
@@ -225,7 +225,7 @@ def test_ensure_ordered_scales() -> None:
                     coordinateTransformations=(
                         Scale(
                             scale=[2.0, 2.0],
-                            input="/0",
+                            input="0",
                             output="out",
                         ),
                     ),
@@ -246,7 +246,7 @@ def test_ensure_ordered_scales() -> None:
                                     output=None,
                                 ),
                             ),
-                            input="/1",
+                            input="1",
                             output="out",
                         ),
                     ),

--- a/tests/_v06/test_transforms.py
+++ b/tests/_v06/test_transforms.py
@@ -22,7 +22,7 @@ def _gen_dataset(
         coordinateTransformations=(
             Scale(
                 scale=scale_factors,
-                input=f"/{path}",
+                input=f"{path}",
                 output=output_coordinate_system,
             ),
         ),

--- a/tests/data/examples/v06/image_label_example.json
+++ b/tests/data/examples/v06/image_label_example.json
@@ -37,21 +37,59 @@
           {
             "name": "coord_sys0",
             "axes": [
-              { "name": "t", "type": "time", "unit": "millisecond" },
-              { "name": "c", "type": "channel" },
-              { "name": "z", "type": "space", "unit": "micrometer" },
-              { "name": "y", "type": "space", "unit": "micrometer" },
-              { "name": "x", "type": "space", "unit": "micrometer" }
+              {
+                "name": "t",
+                "type": "time",
+                "unit": "millisecond"
+              },
+              {
+                "name": "c",
+                "type": "channel"
+              },
+              {
+                "name": "z",
+                "type": "space",
+                "unit": "micrometer"
+              },
+              {
+                "name": "y",
+                "type": "space",
+                "unit": "micrometer"
+              },
+              {
+                "name": "x",
+                "type": "space",
+                "unit": "micrometer"
+              }
             ]
           },
           {
             "name": "coord_sys1",
             "axes": [
-              { "name": "t", "type": "time", "unit": "millisecond" },
-              { "name": "c", "type": "channel" },
-              { "name": "z", "type": "space", "unit": "micrometer" },
-              { "name": "y", "type": "space", "unit": "micrometer" },
-              { "name": "x", "type": "space", "unit": "micrometer" }
+              {
+                "name": "t",
+                "type": "time",
+                "unit": "millisecond"
+              },
+              {
+                "name": "c",
+                "type": "channel"
+              },
+              {
+                "name": "z",
+                "type": "space",
+                "unit": "micrometer"
+              },
+              {
+                "name": "y",
+                "type": "space",
+                "unit": "micrometer"
+              },
+              {
+                "name": "x",
+                "type": "space",
+                "unit": "micrometer"
+              }
             ]
           }
         ],
@@ -62,7 +100,7 @@
               {
                 "type": "scale",
                 "scale": [1.0, 1.0, 0.5, 0.5, 0.5],
-                "input": "/0",
+                "input": "0",
                 "output": "coord_sys0"
               }
             ]
@@ -73,7 +111,7 @@
               {
                 "type": "scale",
                 "scale": [1.0, 1.0, 1.0, 1.0, 1.0],
-                "input": "/1",
+                "input": "1",
                 "output": "coord_sys0"
               }
             ]
@@ -84,7 +122,7 @@
               {
                 "type": "scale",
                 "scale": [1.0, 1.0, 2.0, 2.0, 2.0],
-                "input": "/2",
+                "input": "2",
                 "output": "coord_sys0"
               }
             ]
@@ -103,7 +141,9 @@
           "method": "skimage.transform.pyramid_gaussian",
           "version": "0.16.1",
           "args": "[true]",
-          "kwargs": { "multichannel": true }
+          "kwargs": {
+            "multichannel": true
+          }
         }
       }
     ]

--- a/tests/data/examples/v06/image_no_version_example.json
+++ b/tests/data/examples/v06/image_no_version_example.json
@@ -8,21 +8,59 @@
           {
             "name": "coord_sys0",
             "axes": [
-              { "name": "t", "type": "time", "unit": "millisecond" },
-              { "name": "c", "type": "channel" },
-              { "name": "z", "type": "space", "unit": "micrometer" },
-              { "name": "y", "type": "space", "unit": "micrometer" },
-              { "name": "x", "type": "space", "unit": "micrometer" }
+              {
+                "name": "t",
+                "type": "time",
+                "unit": "millisecond"
+              },
+              {
+                "name": "c",
+                "type": "channel"
+              },
+              {
+                "name": "z",
+                "type": "space",
+                "unit": "micrometer"
+              },
+              {
+                "name": "y",
+                "type": "space",
+                "unit": "micrometer"
+              },
+              {
+                "name": "x",
+                "type": "space",
+                "unit": "micrometer"
+              }
             ]
           },
           {
             "name": "coord_sys1",
             "axes": [
-              { "name": "t", "type": "time", "unit": "millisecond" },
-              { "name": "c", "type": "channel" },
-              { "name": "z", "type": "space", "unit": "micrometer" },
-              { "name": "y", "type": "space", "unit": "micrometer" },
-              { "name": "x", "type": "space", "unit": "micrometer" }
+              {
+                "name": "t",
+                "type": "time",
+                "unit": "millisecond"
+              },
+              {
+                "name": "c",
+                "type": "channel"
+              },
+              {
+                "name": "z",
+                "type": "space",
+                "unit": "micrometer"
+              },
+              {
+                "name": "y",
+                "type": "space",
+                "unit": "micrometer"
+              },
+              {
+                "name": "x",
+                "type": "space",
+                "unit": "micrometer"
+              }
             ]
           }
         ],
@@ -33,7 +71,7 @@
               {
                 "type": "scale",
                 "scale": [1.0, 1.0, 0.5, 0.5, 0.5],
-                "input": "/0",
+                "input": "0",
                 "output": "coord_sys0"
               }
             ]
@@ -44,7 +82,7 @@
               {
                 "type": "scale",
                 "scale": [1.0, 1.0, 1.0, 1.0, 1.0],
-                "input": "/1",
+                "input": "1",
                 "output": "coord_sys0"
               }
             ]
@@ -55,7 +93,7 @@
               {
                 "type": "scale",
                 "scale": [1.0, 1.0, 2.0, 2.0, 2.0],
-                "input": "/2",
+                "input": "2",
                 "output": "coord_sys0"
               }
             ]
@@ -74,7 +112,9 @@
           "method": "skimage.transform.pyramid_gaussian",
           "version": "0.16.1",
           "args": "[true]",
-          "kwargs": { "multichannel": true }
+          "kwargs": {
+            "multichannel": true
+          }
         }
       }
     ]

--- a/tests/data/examples/v06/labels_image_example.json
+++ b/tests/data/examples/v06/labels_image_example.json
@@ -8,21 +8,59 @@
           {
             "name": "coord_sys0",
             "axes": [
-              { "name": "t", "type": "time", "unit": "millisecond" },
-              { "name": "c", "type": "channel" },
-              { "name": "z", "type": "space", "unit": "micrometer" },
-              { "name": "y", "type": "space", "unit": "micrometer" },
-              { "name": "x", "type": "space", "unit": "micrometer" }
+              {
+                "name": "t",
+                "type": "time",
+                "unit": "millisecond"
+              },
+              {
+                "name": "c",
+                "type": "channel"
+              },
+              {
+                "name": "z",
+                "type": "space",
+                "unit": "micrometer"
+              },
+              {
+                "name": "y",
+                "type": "space",
+                "unit": "micrometer"
+              },
+              {
+                "name": "x",
+                "type": "space",
+                "unit": "micrometer"
+              }
             ]
           },
           {
             "name": "coord_sys1",
             "axes": [
-              { "name": "t", "type": "time", "unit": "millisecond" },
-              { "name": "c", "type": "channel" },
-              { "name": "z", "type": "space", "unit": "micrometer" },
-              { "name": "y", "type": "space", "unit": "micrometer" },
-              { "name": "x", "type": "space", "unit": "micrometer" }
+              {
+                "name": "t",
+                "type": "time",
+                "unit": "millisecond"
+              },
+              {
+                "name": "c",
+                "type": "channel"
+              },
+              {
+                "name": "z",
+                "type": "space",
+                "unit": "micrometer"
+              },
+              {
+                "name": "y",
+                "type": "space",
+                "unit": "micrometer"
+              },
+              {
+                "name": "x",
+                "type": "space",
+                "unit": "micrometer"
+              }
             ]
           }
         ],
@@ -33,7 +71,7 @@
               {
                 "type": "scale",
                 "scale": [1.0, 1.0, 0.5, 0.5, 0.5],
-                "input": "/0",
+                "input": "0",
                 "output": "coord_sys0"
               }
             ]


### PR DESCRIPTION
Implements

> The value of “input” MUST equal the value of path, implementations should always treat the value of input as if it were equal to the value of path. The value of the transformation’s output MUST be the name of the “intrinsic” [coordinate system](https://ngff--389.org.readthedocs.build/rfc/5/index.html#id1).

Needs https://github.com/jo-mueller/ngff-rfc5-coordinate-transformation-examples/pull/19 merging first to fix the example metadata.

Half fixes https://github.com/ome-zarr-models/ome-zarr-models-py/issues/273