### PR TITLE
Remove LabelBase from API docs

### DIFF
--- a/src/ome_zarr_models/_v06/image_label_types.py
+++ b/src/ome_zarr_models/_v06/image_label_types.py
@@ -11,7 +11,7 @@ from ome_zarr_models.common.image_label_types import (
     Uint8,
 )
 
-__all__ = ["RGBA", "Color", "LabelBase", "Property", "Source", "Uint8"]
+__all__ = ["RGBA", "Color", "Property", "Source", "Uint8"]
 
 
 class Label(LabelBase):

--- a/src/ome_zarr_models/common/image_label_types.py
+++ b/src/ome_zarr_models/common/image_label_types.py
@@ -11,7 +11,7 @@ from pydantic import Field, field_validator, model_validator
 from ome_zarr_models._utils import duplicates
 from ome_zarr_models.base import BaseAttrs
 
-__all__ = ["RGBA", "Color", "LabelBase", "Property", "Source", "Uint8"]
+__all__ = ["RGBA", "Color", "Property", "Source", "Uint8"]
 
 Uint8 = Annotated[int, Field(strict=True, ge=0, le=255)]
 RGBA = tuple[Uint8, Uint8, Uint8, Uint8]

--- a/src/ome_zarr_models/v04/image_label_types.py
+++ b/src/ome_zarr_models/v04/image_label_types.py
@@ -11,7 +11,7 @@ from ome_zarr_models.common.image_label_types import (
     Uint8,
 )
 
-__all__ = ["RGBA", "Color", "LabelBase", "Property", "Source", "Uint8"]
+__all__ = ["RGBA", "Color", "Property", "Source", "Uint8"]
 
 
 class Label(LabelBase):

--- a/src/ome_zarr_models/v05/image_label_types.py
+++ b/src/ome_zarr_models/v05/image_label_types.py
@@ -11,7 +11,7 @@ from ome_zarr_models.common.image_label_types import (
     Uint8,
 )
 
-__all__ = ["RGBA", "Color", "LabelBase", "Property", "Source", "Uint8"]
+__all__ = ["RGBA", "Color", "Property", "Source", "Uint8"]
 
 
 class Label(LabelBase):


### PR DESCRIPTION
After https://github.com/ome-zarr-models/ome-zarr-models-py/pull/383 this is no longer neeeded because classes show their inherited attributes.