### PR TITLE
Allow the colors field to be absent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 description = "A minimal Python package for reading OME-Zarr (meta)data "
 readme = "README.md"
 requires-python = ">=3.11, <3.14"
-dependencies = ["zarr>= 3.1.1", "pydantic >= 2.11.5", "pydantic-zarr >= 0.8.2"]
+dependencies = ["zarr>= 3.1.1", "pydantic >= 2.11.5, < 2.13", "pydantic-zarr >= 0.8.2"]
 maintainers = [{ name = "David Stansby" }]
 license = { file = "LICENSE" }
 classifiers = [

--- a/src/ome_zarr_models/common/image_label_types.py
+++ b/src/ome_zarr_models/common/image_label_types.py
@@ -102,7 +102,7 @@ class LabelBase(BaseAttrs):
         """
         if colors is None:
             return None
-        
+
         dupes = duplicates(x.label_value for x in colors)
         if len(dupes) > 0:
             msg = (

--- a/src/ome_zarr_models/common/image_label_types.py
+++ b/src/ome_zarr_models/common/image_label_types.py
@@ -94,16 +94,14 @@ class LabelBase(BaseAttrs):
         return self
 
     @field_validator("colors", mode="after")
-    def _parse_colors(cls, colors: tuple[Color, ...]) -> tuple[Color, ...]:
+    def _parse_colors(
+        cls, colors: tuple[Color, ...] | None
+    ) -> tuple[Color, ...] | None:
         """
         Check that color label values are unique.
         """
-        # if colors is None:
-        #    msg = (
-        #        "The field `colors` is `None`. `colors` should be a list of "
-        #        "label descriptors."
-        #    )
-        #    warnings.warn(msg, stacklevel=1)
+        if colors is None:
+            return None
         
         dupes = duplicates(x.label_value for x in colors)
         if len(dupes) > 0:

--- a/src/ome_zarr_models/common/image_label_types.py
+++ b/src/ome_zarr_models/common/image_label_types.py
@@ -94,16 +94,12 @@ class LabelBase(BaseAttrs):
         return self
 
     @field_validator("colors", mode="after")
-    def _parse_colors(cls, colors: tuple[Color, ...]) -> tuple[Color, ...]:
+    def _parse_colors(cls, colors: tuple[Color, ...] | None) -> tuple[Color, ...] | None:
         """
         Check that color label values are unique.
         """
-        # if colors is None:
-        #    msg = (
-        #        "The field `colors` is `None`. `colors` should be a list of "
-        #        "label descriptors."
-        #    )
-        #    warnings.warn(msg, stacklevel=1)
+        if colors is None:
+            return None
         dupes = duplicates(x.label_value for x in colors)
         if len(dupes) > 0:
             msg = (

--- a/src/ome_zarr_models/common/image_label_types.py
+++ b/src/ome_zarr_models/common/image_label_types.py
@@ -2,6 +2,8 @@
 For reference, see the [image label section of the OME-Zarr specification](https://ngff.openmicroscopy.org/0.4/index.html#label-md).
 """
 
+from __future__ import annotations
+
 from typing import Annotated, Self
 
 from pydantic import Field, field_validator, model_validator
@@ -92,14 +94,17 @@ class LabelBase(BaseAttrs):
         return self
 
     @field_validator("colors", mode="after")
-    def _parse_colors(
-        cls, colors: tuple[Color, ...] | None
-    ) -> tuple[Color, ...] | None:
+    def _parse_colors(cls, colors: tuple[Color, ...]) -> tuple[Color, ...]:
         """
         Check that color label values are unique.
         """
-        if colors is None:
-            return None
+        # if colors is None:
+        #    msg = (
+        #        "The field `colors` is `None`. `colors` should be a list of "
+        #        "label descriptors."
+        #    )
+        #    warnings.warn(msg, stacklevel=1)
+        
         dupes = duplicates(x.label_value for x in colors)
         if len(dupes) > 0:
             msg = (

--- a/src/ome_zarr_models/common/image_label_types.py
+++ b/src/ome_zarr_models/common/image_label_types.py
@@ -94,7 +94,9 @@ class LabelBase(BaseAttrs):
         return self
 
     @field_validator("colors", mode="after")
-    def _parse_colors(cls, colors: tuple[Color, ...] | None) -> tuple[Color, ...] | None:
+    def _parse_colors(
+        cls, colors: tuple[Color, ...] | None
+    ) -> tuple[Color, ...] | None:
         """
         Check that color label values are unique.
         """

--- a/src/ome_zarr_models/common/image_label_types.py
+++ b/src/ome_zarr_models/common/image_label_types.py
@@ -2,8 +2,6 @@
 For reference, see the [image label section of the OME-Zarr specification](https://ngff.openmicroscopy.org/0.4/index.html#label-md).
 """
 
-from __future__ import annotations
-
 from typing import Annotated, Self
 
 from pydantic import Field, field_validator, model_validator

--- a/src/ome_zarr_models/v04/image.py
+++ b/src/ome_zarr_models/v04/image.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Self
 
 from pydantic import Field, JsonValue, model_validator
@@ -15,8 +16,6 @@ from ome_zarr_models.v04.multiscales import Dataset, Multiscale
 from ome_zarr_models.v04.omero import Omero
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-
     import zarr
 
 

--- a/src/ome_zarr_models/v04/image.py
+++ b/src/ome_zarr_models/v04/image.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import TYPE_CHECKING, Self
 
 from pydantic import Field, JsonValue, model_validator
@@ -16,6 +15,8 @@ from ome_zarr_models.v04.multiscales import Dataset, Multiscale
 from ome_zarr_models.v04.omero import Omero
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     import zarr
 
 

--- a/tests/_v06/test_image_label.py
+++ b/tests/_v06/test_image_label.py
@@ -8,6 +8,14 @@ from ome_zarr_models._v06.multiscales import Dataset, Multiscale
 from tests._v06.conftest import json_to_zarr_group
 
 
+def test_null_colors() -> None:
+    """
+    Check that colors=None is valid.
+    """
+    label = Label(colors=None)
+    assert label.colors is None
+
+
 def test_image_label(store: Store) -> None:
     zarr_group = json_to_zarr_group(json_fname="image_label_example.json", store=store)
     zarr_group.create_array(

--- a/tests/v04/test_image_label.py
+++ b/tests/v04/test_image_label.py
@@ -89,6 +89,14 @@ def test_invalid_rgba() -> None:
         Color(label_value=1, rgba=(255, 255, 3412, 255))
 
 
+def test_null_colors() -> None:
+    """
+    Check that colors=None is valid.
+    """
+    label = Label(colors=None, version="0.4")
+    assert label.colors is None
+
+
 def test_default_source() -> None:
     """
     Check that default image source is '../../'

--- a/tests/v05/test_image_label.py
+++ b/tests/v05/test_image_label.py
@@ -8,6 +8,14 @@ from ome_zarr_models.v05.multiscales import Dataset, Multiscale
 from tests.v05.conftest import json_to_zarr_group
 
 
+def test_null_colors() -> None:
+    """
+    Check that colors=None is valid.
+    """
+    label = Label(colors=None)
+    assert label.colors is None
+
+
 def test_image_label(store: Store) -> None:
     zarr_group = json_to_zarr_group(json_fname="image_label_example.json", store=store)
     zarr_group.create_array(


### PR DESCRIPTION
* image-label > colors is not a required field accorrding to [NGFF spec](https://ngff.openmicroscopy.org/specifications/dev/schemas/label.html#property-label-ome-image-label-colors)
* The pydantic model already accepts `None` as a value, however the field validator assumes it's a list. 
* Pins `pydantic` version to `<3.13`. Tests fail with `Class not fully defined ` errors otherwise