### PR TITLE
feat: allow 0.6.dev4 metadata

### DIFF
--- a/src/ome_zarr_models/_v06/base.py
+++ b/src/ome_zarr_models/_v06/base.py
@@ -19,7 +19,7 @@ class BaseOMEAttrs(BaseAttrsv3):
 
     # TODO: added 0.6.dev* to allow for RFC5 testing.
     # Remove this before final release!
-    version: Literal["0.6", "0.6.dev1", "0.6.dev2", "0.6.dev3"]
+    version: Literal["0.6", "0.6.dev1", "0.6.dev2", "0.6.dev3", "0.6.dev4"]
 
 
 T = TypeVar("T", bound=BaseOMEAttrs)


### PR DESCRIPTION
Breakout from #422. Necessary to parse 0.6.dev4 metadata to begin with. More PRs to follow!