### PR TITLE
feat: make interpolation optional

### DIFF
--- a/src/ome_zarr_models/_v06/coordinate_transforms.py
+++ b/src/ome_zarr_models/_v06/coordinate_transforms.py
@@ -616,6 +616,9 @@ class Displacements(Transform):
 
     type: Literal["displacements"] = "displacements"
     path: str = Field(..., description="Path to the Zarr array displacement field.")
+    interpolation: str | None = Field(
+        default=None, description="Interpolation method to be used when applying the transform (default: 'linear')."
+    )
 
     @property
     def has_inverse(self) -> bool:
@@ -644,6 +647,11 @@ class Coordinates(Transform):
     type: Literal["coordinates"] = "coordinates"
     path: str = Field(
         ..., description="Path to the Zarr array containing the coordinate mapping."
+    )
+    interpolation: str | None = Field(
+        default=None,
+        description="Interpolation scheme that should be used when applying"
+        " the transform.",
     )
 
     @property

--- a/src/ome_zarr_models/_v06/coordinate_transforms.py
+++ b/src/ome_zarr_models/_v06/coordinate_transforms.py
@@ -650,8 +650,7 @@ class Coordinates(Transform):
     )
     interpolation: str | None = Field(
         default=None,
-        description="Interpolation scheme that should be used when applying"
-        " the transform.",
+        description="Interpolation method to be used after applying the transform."
     )
 
     @property

--- a/src/ome_zarr_models/_v06/coordinate_transforms.py
+++ b/src/ome_zarr_models/_v06/coordinate_transforms.py
@@ -617,7 +617,7 @@ class Displacements(Transform):
     type: Literal["displacements"] = "displacements"
     path: str = Field(..., description="Path to the Zarr array displacement field.")
     interpolation: str | None = Field(
-        default=None, description="Interpolation method to be used when applying the transform (default: 'linear')."
+        default=None, description="Interpolation method to be used after applying the transform."
     )
 
     @property


### PR DESCRIPTION
Title. The interpolation field of the `coordinates` and `displacements` transform should be optional.