### PR TITLE
feat: remove default coordinate system

### DIFF
--- a/src/ome_zarr_models/_v06/multiscales.py
+++ b/src/ome_zarr_models/_v06/multiscales.py
@@ -55,20 +55,6 @@ class Multiscale(BaseAttrs):
         return self.intrinsic_coordinate_system.ndim
 
     @property
-    def default_coordinate_system(self) -> CoordinateSystem:
-        """
-        The default coordinate system for this multiscales.
-
-        Any references to this multiscales in coordinate transformations will resolve
-        to this coordinate system.
-
-        Notes
-        -----
-        This is the first entry in the `coordinateSystems` attribute.
-        """
-        return self.coordinateSystems[0]
-
-    @property
     def intrinsic_coordinate_system(self) -> CoordinateSystem:
         """
         Physical coordinate system.

--- a/tests/_v06/test_multiscales.py
+++ b/tests/_v06/test_multiscales.py
@@ -294,13 +294,6 @@ def test_default_coordinate_systems() -> None:
             Axis(name="i", type=None, discrete=None, unit=None, longName=None),
         ),
     )
-    assert multiscale.default_coordinate_system == CoordinateSystem(
-        name="an_other_system",
-        axes=(
-            Axis(name="x", type=None, discrete=None, unit=None, longName=None),
-            Axis(name="y", type=None, discrete=None, unit=None, longName=None),
-        ),
-    )
 
 
 def test_from_v05() -> None:


### PR DESCRIPTION
Used to be declared as default because of its position in the coordinate systems list. This ordering is no longer relevant so the default coordinate system is no longer necessary.