### PR TITLE
Set codecov patch target to 0%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,8 @@
 comment: false
+coverage:
+  status:
+    patch:
+      default:
+        # Set to 0% to avoid failing GitHub status checks
+        # The actual value will still show as a status check in the GH UI
+        target: 0%


### PR DESCRIPTION
Inspired by @jo-mueller's PR at https://github.com/ome-zarr-models/ome-zarr-models-py/pull/428, I think it makes sense to set this to 0% so the status checks aren't failing on patch coverage.