### PR TITLE
Simplify scale translate transforms

### DIFF
--- a/src/ome_zarr_models/_v06/coordinate_transforms.py
+++ b/src/ome_zarr_models/_v06/coordinate_transforms.py
@@ -242,9 +242,7 @@ class Translation(Transform):
     """Translation transformation."""
 
     type: Literal["translation"] = "translation"
-    translation: tuple[float, ...] = Field(
-        description="Translation vector."
-    )
+    translation: tuple[float, ...] = Field(description="Translation vector.")
 
     @property
     def ndim(self) -> int:
@@ -282,9 +280,7 @@ class Scale(Transform):
     """Scale transformation."""
 
     type: Literal["scale"] = "scale"
-    scale: tuple[float, ...] = Field(
-        description="Scale factors for each axis."
-    )
+    scale: tuple[float, ...] = Field(description="Scale factors for each axis.")
 
     @property
     def has_inverse(self) -> bool:
@@ -320,6 +316,7 @@ class Scale(Transform):
             output=self.output,
             name=self.name,
         )
+
 
 class Affine(Transform):
     """Affine transform."""

--- a/src/ome_zarr_models/_v06/coordinate_transforms.py
+++ b/src/ome_zarr_models/_v06/coordinate_transforms.py
@@ -242,11 +242,8 @@ class Translation(Transform):
     """Translation transformation."""
 
     type: Literal["translation"] = "translation"
-    translation: tuple[float, ...] | None = Field(
-        default=None, description="Translation vector."
-    )
-    path: str | None = Field(
-        default=None, description="Path to translation vector stored as a Zarr array."
+    translation: tuple[float, ...] = Field(
+        description="Translation vector."
     )
 
     @property
@@ -254,7 +251,7 @@ class Translation(Transform):
         """
         Number of dimensions.
         """
-        return len(self.translation_vector)
+        return len(self.translation)
 
     @property
     def has_inverse(self) -> bool:
@@ -265,51 +262,28 @@ class Translation(Transform):
             input=self.output,
             output=self.input,
             name=self._inverse_name,
-            translation=tuple([-i for i in self.translation_vector]),
+            translation=tuple([-i for i in self.translation]),
         )
 
-    @property
-    def translation_vector(self) -> tuple[float, ...]:
-        """
-        Translation vector for this transform.
-        """
-        if self.translation is not None:
-            return self.translation
-        elif self.path is not None:
-            raise NotImplementedError(
-                "Loading translation from a Zarr array not yet implemented"
-            )
-        else:
-            raise RuntimeError("Both self.translation and self.path are None")
-
     def transform_point(self, point: typing.Sequence[float]) -> tuple[float, ...]:
-        return tuple(p + t for p, t in zip(point, self.translation_vector, strict=True))
+        return tuple(p + t for p, t in zip(point, self.translation, strict=True))
 
     def as_affine(self) -> "Affine":
         return Affine._from_matrix_vector(
             matrix=tuple(tuple(row) for row in np.identity(self.ndim)),
-            vector=self.translation_vector,
+            vector=self.translation,
             input=self.input,
             output=self.output,
             name=self.name,
         )
-
-    @model_validator(mode="after")
-    def check_metadata_set(self) -> Self:
-        if self.translation is None and self.path is None:
-            raise ValueError("One of 'translation' or 'path' must be given")
-        return self
 
 
 class Scale(Transform):
     """Scale transformation."""
 
     type: Literal["scale"] = "scale"
-    scale: tuple[float, ...] | None = Field(
-        default=None, description="Scale factors for each axis."
-    )
-    path: str | None = Field(
-        default=None, description="Path to scale factors stored in a Zarr array."
+    scale: tuple[float, ...] = Field(
+        description="Scale factors for each axis."
     )
 
     @property
@@ -321,36 +295,22 @@ class Scale(Transform):
             input=self.output,
             output=self.input,
             name=self._inverse_name,
-            scale=tuple([1 / i for i in self.scale_vector]),
+            scale=tuple([1 / i for i in self.scale]),
         )
-
-    @property
-    def scale_vector(self) -> tuple[float, ...]:
-        """
-        Scale vector for this transform.
-        """
-        if self.scale is not None:
-            return self.scale
-        elif self.path is not None:
-            raise NotImplementedError(
-                "Loading scale from a Zarr array not yet implemented"
-            )
-        else:
-            raise RuntimeError("Both self.scale and self.path are None")
 
     @property
     def ndim(self) -> int:
         """
         Number of dimensions.
         """
-        return len(self.scale_vector)
+        return len(self.scale)
 
     def transform_point(self, point: typing.Sequence[float]) -> tuple[float, ...]:
-        return tuple(p * s for p, s in zip(point, self.scale_vector, strict=True))
+        return tuple(p * s for p, s in zip(point, self.scale, strict=True))
 
     def as_affine(self) -> "Affine":
         matrix = np.identity(self.ndim)
-        for i, scale in enumerate(self.scale_vector):
+        for i, scale in enumerate(self.scale):
             matrix[i, i] = scale
 
         return Affine._from_matrix_vector(
@@ -360,13 +320,6 @@ class Scale(Transform):
             output=self.output,
             name=self.name,
         )
-
-    @model_validator(mode="after")
-    def check_metadata_set(self) -> Self:
-        if self.scale is None and self.path is None:
-            raise ValueError("One of 'scale' or 'path' must be given")
-        return self
-
 
 class Affine(Transform):
     """Affine transform."""

--- a/src/ome_zarr_models/_v06/multiscales.py
+++ b/src/ome_zarr_models/_v06/multiscales.py
@@ -155,7 +155,7 @@ class Multiscale(BaseAttrs):
                 scale = transform.transformations[0]
                 scale_transforms.append(scale)
 
-        scales = [s.scale_vector for s in scale_transforms]
+        scales = [s.scale for s in scale_transforms]
         for i in range(len(scales) - 1):
             s1, s2 = scales[i], scales[i + 1]
             is_ordered = all(s1[j] <= s2[j] for j in range(len(s1)))

--- a/src/ome_zarr_models/_v06/scene.py
+++ b/src/ome_zarr_models/_v06/scene.py
@@ -18,7 +18,7 @@ from ome_zarr_models._v06.image import Image
 
 class SceneAttrs(BaseModel):
     coordinateTransformations: tuple[AnyTransform, ...] = Field(default=())
-    coordinateSystems: tuple[CoordinateSystem, ...] = Field(default=())
+    coordinateSystems: tuple[CoordinateSystem, ...] | None = Field(default=None)
 
 
 class BaseSceneAttrs(BaseOMEAttrs):
@@ -132,8 +132,9 @@ class Scene(BaseGroupv06[BaseSceneAttrs]):
         graph = TransformGraph()
 
         # Coordinate systems
-        for system in self.ome_attributes.scene.coordinateSystems:
-            graph.add_system(system)
+        if self.ome_attributes.scene.coordinateSystems is not None:
+            for system in self.ome_attributes.scene.coordinateSystems:
+                graph.add_system(system)
         # Coordinate transforms
         for transform in self.ome_attributes.scene.coordinateTransformations:
             graph.add_transform(transform)

--- a/src/ome_zarr_models/v05/multiscales.py
+++ b/src/ome_zarr_models/v05/multiscales.py
@@ -470,8 +470,6 @@ def _v05_transform_to_v06(transform: ValidTransform) -> ScaleV06 | SequenceV06:
     # Scale (always present)
     if isinstance(transform[0], VectorScale):
         scale = ScaleV06(scale=tuple(transform[0].scale))
-    else:
-        scale = ScaleV06(path=transform[0].path)
 
     if len(transform) == 1:
         return scale
@@ -480,6 +478,4 @@ def _v05_transform_to_v06(transform: ValidTransform) -> ScaleV06 | SequenceV06:
         # Translate
         if isinstance(transform[1], VectorTranslation):
             translate = TranslationV06(translation=tuple(transform[1].translation))
-        else:
-            translate = TranslationV06(path=transform[1].translation)
         return SequenceV06(transformations=(scale, translate))

--- a/src/ome_zarr_models/v05/multiscales.py
+++ b/src/ome_zarr_models/v05/multiscales.py
@@ -476,7 +476,8 @@ def _v05_transform_to_v06(transform: ValidTransform) -> ScaleV06 | SequenceV06:
         scale = ScaleV06(scale=tuple(transform[0].scale))
     elif isinstance(transform[0], PathScale):
         raise NotImplementedError(
-            "Conversion of PathScale transforms from 0.5 to 0.6 is not currently supported."
+            "Conversion of PathScale transforms from 0.5 to 0.6 "
+            "is not currently supported."
         )
 
     if len(transform) == 1:
@@ -488,6 +489,7 @@ def _v05_transform_to_v06(transform: ValidTransform) -> ScaleV06 | SequenceV06:
             translate = TranslationV06(translation=tuple(transform[1].translation))
         elif isinstance(transform[1], PathTranslation):
             raise NotImplementedError(
-                "Conversion of PathTranslation transforms from 0.5 to 0.6 is not currently supported."
+                "Conversion of PathTranslation transforms from 0.5 to 0.6 "
+                "is not currently supported."
             )
         return SequenceV06(transformations=(scale, translate))

--- a/src/ome_zarr_models/v05/multiscales.py
+++ b/src/ome_zarr_models/v05/multiscales.py
@@ -467,9 +467,15 @@ def _v05_transform_to_v06(transform: ValidTransform) -> ScaleV06 | SequenceV06:
         VectorTranslation,
     )
 
+    from ome_zarr_models.v05.coordinate_transformations import PathScale, PathTranslation
+
     # Scale (always present)
     if isinstance(transform[0], VectorScale):
         scale = ScaleV06(scale=tuple(transform[0].scale))
+    elif isinstance(transform[0], PathScale):
+        raise NotImplementedError(
+            "Conversion of PathScale transforms from 0.5 to 0.6 is not currently supported."
+        )
 
     if len(transform) == 1:
         return scale
@@ -478,4 +484,8 @@ def _v05_transform_to_v06(transform: ValidTransform) -> ScaleV06 | SequenceV06:
         # Translate
         if isinstance(transform[1], VectorTranslation):
             translate = TranslationV06(translation=tuple(transform[1].translation))
+        elif isinstance(transform[1], PathTranslation):
+            raise NotImplementedError(
+                "Conversion of PathTranslation transforms from 0.5 to 0.6 is not currently supported."
+            )
         return SequenceV06(transformations=(scale, translate))

--- a/src/ome_zarr_models/v05/multiscales.py
+++ b/src/ome_zarr_models/v05/multiscales.py
@@ -466,8 +466,10 @@ def _v05_transform_to_v06(transform: ValidTransform) -> ScaleV06 | SequenceV06:
         VectorScale,
         VectorTranslation,
     )
-
-    from ome_zarr_models.v05.coordinate_transformations import PathScale, PathTranslation
+    from ome_zarr_models.v05.coordinate_transformations import (
+        PathScale,
+        PathTranslation,
+    )
 
     # Scale (always present)
     if isinstance(transform[0], VectorScale):

--- a/tests/_v06/test_collection.py
+++ b/tests/_v06/test_collection.py
@@ -65,7 +65,6 @@ def test_load_container() -> None:
                                             },
                                             "name": "tile_0 to physical",
                                             "scale": (1.0, 1.0),
-                                            "path": None,
                                         },
                                     ),
                                 },
@@ -148,7 +147,6 @@ def test_load_container() -> None:
                                             },
                                             "name": "tile_1 to physical",
                                             "scale": (1.0, 1.0),
-                                            "path": None,
                                         },
                                     ),
                                 },
@@ -200,7 +198,6 @@ def test_load_container() -> None:
                     output=CoordinateSystemIdentifier(name="world"),
                     name="tile_0_mm to world",
                     translation=(0.0, 0.0),
-                    path=None,
                 ),
                 Translation(
                     type="translation",
@@ -208,7 +205,6 @@ def test_load_container() -> None:
                     output=CoordinateSystemIdentifier(name="world"),
                     name="tile_1_mm to world",
                     translation=(0.0, 348.0),
-                    path=None,
                 ),
             ),
             coordinateSystems=(

--- a/tests/_v06/test_collection.py
+++ b/tests/_v06/test_collection.py
@@ -351,6 +351,7 @@ def test_scene_new() -> None:
     assert coord_transform_1.translation == (0, 256)
 
     # Verify coordinate systems
+    assert scene.ome_attributes.scene.coordinateSystems is not None
     assert len(scene.ome_attributes.scene.coordinateSystems) == 1
     assert scene.ome_attributes.scene.coordinateSystems[0].name == "world"
 

--- a/tests/_v06/test_coordinate_transforms.py
+++ b/tests/_v06/test_coordinate_transforms.py
@@ -18,7 +18,7 @@ from ome_zarr_models._v06.coordinate_transforms import (
 )
 
 
-@pytest.mark.parametrize("transform_cls", (Translation, Scale, Affine, Rotation))
+@pytest.mark.parametrize("transform_cls", (Affine, Rotation))
 def test_no_parameters(transform_cls: type[Transform]) -> None:
     # Check that errors are raised with classes that require either parameters,
     # OR paths to a Zarr array with those parameters.

--- a/tests/_v06/test_image.py
+++ b/tests/_v06/test_image.py
@@ -134,8 +134,7 @@ def test_image(store: Store) -> None:
                                 input=CoordinateSystemIdentifier(path="0"),
                                 output=CoordinateSystemIdentifier(name="coord_sys0"),
                                 name=None,
-                                scale=(1.0, 1.0, 0.5, 0.5, 0.5),
-                                path=None,
+                                scale=(1.0, 1.0, 0.5, 0.5, 0.5)
                             ),
                         ),
                     ),
@@ -147,8 +146,7 @@ def test_image(store: Store) -> None:
                                 input=CoordinateSystemIdentifier(path="1"),
                                 output=CoordinateSystemIdentifier(name="coord_sys0"),
                                 name=None,
-                                scale=(1.0, 1.0, 1.0, 1.0, 1.0),
-                                path=None,
+                                scale=(1.0, 1.0, 1.0, 1.0, 1.0)
                             ),
                         ),
                     ),
@@ -160,8 +158,7 @@ def test_image(store: Store) -> None:
                                 input=CoordinateSystemIdentifier(path="2"),
                                 output=CoordinateSystemIdentifier(name="coord_sys0"),
                                 name=None,
-                                scale=(1.0, 1.0, 2.0, 2.0, 2.0),
-                                path=None,
+                                scale=(1.0, 1.0, 2.0, 2.0, 2.0)
                             ),
                         ),
                     ),
@@ -172,8 +169,7 @@ def test_image(store: Store) -> None:
                         input=CoordinateSystemIdentifier(name="coord_sys0"),
                         output=CoordinateSystemIdentifier(name="coord_sys1"),
                         name=None,
-                        scale=(0.1, 1.0, 1.0, 1.0, 1.0),
-                        path=None,
+                        scale=(0.1, 1.0, 1.0, 1.0, 1.0)
                     ),
                 ),
                 metadata={
@@ -303,7 +299,6 @@ def test_image_new() -> None:
                                         output=None,
                                         name=None,
                                         scale=(1.0, 1.0),
-                                        path=None,
                                     ),
                                     Translation(
                                         type="translation",
@@ -311,7 +306,6 @@ def test_image_new() -> None:
                                         output=None,
                                         name=None,
                                         translation=(0.0, 0.0),
-                                        path=None,
                                     ),
                                 ),
                             ),
@@ -334,7 +328,6 @@ def test_image_new() -> None:
                                         output=None,
                                         name=None,
                                         scale=(2.0, 2.0),
-                                        path=None,
                                     ),
                                     Translation(
                                         type="translation",
@@ -342,7 +335,6 @@ def test_image_new() -> None:
                                         output=None,
                                         name=None,
                                         translation=(1.0, 1.0),
-                                        path=None,
                                     ),
                                 ),
                             ),
@@ -391,7 +383,6 @@ def test_transform_graph() -> None:
                 output=CoordinateSystemIdentifier(name="coord_sys1"),
                 name=None,
                 scale=(0.1, 1.0, 1.0, 1.0, 1.0),
-                path=None,
             )
         },
         TransformGraphNode(name=None, path="0"): {
@@ -401,7 +392,6 @@ def test_transform_graph() -> None:
                 output=CoordinateSystemIdentifier(name="coord_sys0"),
                 name=None,
                 scale=(1.0, 1.0, 0.5, 0.5, 0.5),
-                path=None,
             )
         },
         TransformGraphNode(name=None, path="1"): {
@@ -411,7 +401,6 @@ def test_transform_graph() -> None:
                 output=CoordinateSystemIdentifier(name="coord_sys0"),
                 name=None,
                 scale=(1.0, 1.0, 1.0, 1.0, 1.0),
-                path=None,
             )
         },
         TransformGraphNode(name=None, path="2"): {
@@ -421,7 +410,6 @@ def test_transform_graph() -> None:
                 output=CoordinateSystemIdentifier(name="coord_sys0"),
                 name=None,
                 scale=(1.0, 1.0, 2.0, 2.0, 2.0),
-                path=None,
             )
         },
     }

--- a/tests/_v06/test_image.py
+++ b/tests/_v06/test_image.py
@@ -134,7 +134,7 @@ def test_image(store: Store) -> None:
                                 input=CoordinateSystemIdentifier(path="0"),
                                 output=CoordinateSystemIdentifier(name="coord_sys0"),
                                 name=None,
-                                scale=(1.0, 1.0, 0.5, 0.5, 0.5)
+                                scale=(1.0, 1.0, 0.5, 0.5, 0.5),
                             ),
                         ),
                     ),
@@ -146,7 +146,7 @@ def test_image(store: Store) -> None:
                                 input=CoordinateSystemIdentifier(path="1"),
                                 output=CoordinateSystemIdentifier(name="coord_sys0"),
                                 name=None,
-                                scale=(1.0, 1.0, 1.0, 1.0, 1.0)
+                                scale=(1.0, 1.0, 1.0, 1.0, 1.0),
                             ),
                         ),
                     ),
@@ -158,7 +158,7 @@ def test_image(store: Store) -> None:
                                 input=CoordinateSystemIdentifier(path="2"),
                                 output=CoordinateSystemIdentifier(name="coord_sys0"),
                                 name=None,
-                                scale=(1.0, 1.0, 2.0, 2.0, 2.0)
+                                scale=(1.0, 1.0, 2.0, 2.0, 2.0),
                             ),
                         ),
                     ),
@@ -169,7 +169,7 @@ def test_image(store: Store) -> None:
                         input=CoordinateSystemIdentifier(name="coord_sys0"),
                         output=CoordinateSystemIdentifier(name="coord_sys1"),
                         name=None,
-                        scale=(0.1, 1.0, 1.0, 1.0, 1.0)
+                        scale=(0.1, 1.0, 1.0, 1.0, 1.0),
                     ),
                 ),
                 metadata={

--- a/tests/_v06/test_multiscales.py
+++ b/tests/_v06/test_multiscales.py
@@ -379,7 +379,6 @@ def test_from_v05() -> None:
                                 output=None,
                                 name=None,
                                 scale=(2.0, -4.0),
-                                path=None,
                             ),
                             Translation(
                                 type="translation",
@@ -387,7 +386,6 @@ def test_from_v05() -> None:
                                 output=None,
                                 name=None,
                                 translation=(5.0, 3.0),
-                                path=None,
                             ),
                         ),
                     ),
@@ -401,7 +399,6 @@ def test_from_v05() -> None:
                 output=CoordinateSystemIdentifier(name="output", path=None),
                 name=None,
                 scale=(6.0, 3.0),
-                path=None,
             ),
         ),
         metadata={"key": "value"},


### PR DESCRIPTION
Fixes #435 

Based on #433 

This PR removes the `path` fields from the scale and translation transforms.

Re-opened from #437 for clean commit history.

I slipped in another thing I noticed: In the `SceneAttrs` class, `coordinateSystems` cannot be set to `None`, but the spec allows scene metadata without coordinate systems.