### PR TITLE
feat: add downconverter for 0.6->0.5

### DIFF
--- a/src/ome_zarr_models/_v06/multiscales.py
+++ b/src/ome_zarr_models/_v06/multiscales.py
@@ -58,6 +58,18 @@ class Multiscale(BaseAttrs):
     def to_version(
         self, version: Literal["0.4", "0.5"]
     ) -> Multiscalev05 | Multiscalev04:
+        """
+        Convert this Multiscale metadata to the specified version.
+
+        Currently supported conversions are
+        - 0.6 -> 0.5
+        - 0.6 -> 0.4
+
+        Parameters
+        ----------
+        version
+            The version to convert to. Must be one of "0.4" or "0.5".
+        """
         if version == "0.5":
             return self._to_v05()
         elif version == "0.4":

--- a/src/ome_zarr_models/_v06/multiscales.py
+++ b/src/ome_zarr_models/_v06/multiscales.py
@@ -127,7 +127,7 @@ class Multiscale(BaseAttrs):
 
         if self.coordinateTransformations is not None:
             warnings.warn(
-                "Coordinate transformations defined in coordinateTransformations "
+                "Coordinate transformations defined in multiscales > coordinateTransformations "
                 "can currently not be converted to v0.5, "
                 "as they are not supported in this version.",
                 stacklevel=2,

--- a/src/ome_zarr_models/_v06/multiscales.py
+++ b/src/ome_zarr_models/_v06/multiscales.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import typing
+import warnings
 from collections import Counter
-from typing import Annotated, Self
+from typing import Annotated, Self, overload, Literal, TYPE_CHECKING
 
 from pydantic import (
     Field,
@@ -24,6 +25,10 @@ from ome_zarr_models._v06.coordinate_transforms import (
 from ome_zarr_models.base import BaseAttrs
 from ome_zarr_models.common.validation import check_length, unique_items_validator
 
+if TYPE_CHECKING:
+    from ome_zarr_models.v04.multiscales import Multiscale as Multiscalev04
+    from ome_zarr_models.v05.multiscales import Multiscale as Multiscalev05
+
 __all__ = ["Dataset", "Multiscale"]
 
 
@@ -38,6 +43,104 @@ class Multiscale(BaseAttrs):
     metadata: JsonValue = None
     name: JsonValue | None = None
     type: JsonValue = None
+
+    @overload
+    def to_version(self, version: Literal["0.4"]) -> Multiscalev04:
+        pass
+
+    @overload
+    def to_version(
+        self,
+        version: Literal["0.5"],
+    ) -> Multiscalev05:
+        pass
+
+    def to_version(
+        self, version: Literal["0.4", "0.5"]
+    ) -> Multiscalev05 | Multiscalev04:
+        if version == "0.5":
+            return self._to_v05()
+        elif version == "0.4":
+            return self._to_v05()._to_v04()
+        else:
+            raise ValueError(f"Unsupported version: {version}")
+
+    def _to_v05(self) -> Multiscalev05:
+        from ome_zarr_models.common.coordinate_transformations import (
+            ValidTransform,
+        )
+        from ome_zarr_models.v05.axes import Axis as Axisv05
+        from ome_zarr_models.v05.coordinate_transformations import (
+            VectorScale,
+            VectorTranslation,
+        )
+        from ome_zarr_models.v05.multiscales import (
+            Dataset as Datasetv05,
+        )
+        from ome_zarr_models.v05.multiscales import (
+            Multiscale as Multiscalev05,
+        )
+
+        intrinsic_cs = self.intrinsic_coordinate_system
+        axes = tuple(
+            [
+                Axisv05(name=axis.name, type=axis.type, unit=axis.unit)
+                for axis in intrinsic_cs.axes
+            ]
+        )
+
+        datasets = []
+        for ds in self.datasets:
+            scale_transform: VectorScale | None = None
+            translation_transform: VectorTranslation | None = None
+
+            for tf in ds.coordinateTransformations:
+                if isinstance(tf, Scale):
+                    scale_transform = VectorScale(type="scale", scale=list(tf.scale))
+                elif isinstance(tf, Sequence):
+                    for sub_tf in tf.transformations:
+                        if isinstance(sub_tf, Scale):
+                            scale_transform = VectorScale(
+                                type="scale", scale=list(sub_tf.scale)
+                            )
+                        elif isinstance(sub_tf, Translation):
+                            translation_transform = VectorTranslation(
+                                type="translation", translation=list(sub_tf.translation)
+                            )
+                        else:
+                            raise ValueError(
+                                f"Unsupported transform type: {type(sub_tf)}"
+                            )
+
+            if scale_transform is None:
+                raise ValueError("No scale transform found")
+
+            coord_transforms: ValidTransform
+            if translation_transform is not None:
+                coord_transforms = (scale_transform, translation_transform)
+            else:
+                coord_transforms = (scale_transform,)
+
+            datasets.append(
+                Datasetv05(path=ds.path, coordinateTransformations=coord_transforms)
+            )
+
+        if self.coordinateTransformations is not None:
+            warnings.warn(
+                "Coordinate transformations defined in coordinateTransformations "
+                "can currently not be converted to v0.5, "
+                "as they are not supported in this version.",
+                stacklevel=2,
+            )
+
+        new_ms = Multiscalev05(
+            name=self.name,
+            type=self.type,
+            metadata=self.metadata,
+            axes=axes,
+            datasets=tuple(datasets),
+        )
+        return new_ms
 
     @property
     def ndim(self) -> int:

--- a/src/ome_zarr_models/_v06/multiscales.py
+++ b/src/ome_zarr_models/_v06/multiscales.py
@@ -127,7 +127,8 @@ class Multiscale(BaseAttrs):
 
         if self.coordinateTransformations is not None:
             warnings.warn(
-                "Coordinate transformations defined in multiscales > coordinateTransformations "
+                "Coordinate transformations defined in "
+                "multiscales > coordinateTransformations "
                 "can currently not be converted to v0.5, "
                 "as they are not supported in this version.",
                 stacklevel=2,

--- a/src/ome_zarr_models/_v06/multiscales.py
+++ b/src/ome_zarr_models/_v06/multiscales.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing
 import warnings
 from collections import Counter
-from typing import Annotated, Self, overload, Literal, TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated, Literal, Self, overload
 
 from pydantic import (
     Field,

--- a/tests/_v06/test_multiscales.py
+++ b/tests/_v06/test_multiscales.py
@@ -415,6 +415,7 @@ def test_from_v05() -> None:
         == ms_target
     )
 
+
 def test_from_v06_to_v05() -> None:
     """Test conversion from v0.6 to v0.5."""
     ms = Multiscale(

--- a/tests/_v06/test_multiscales.py
+++ b/tests/_v06/test_multiscales.py
@@ -415,6 +415,74 @@ def test_from_v05() -> None:
         == ms_target
     )
 
+def test_from_v06_to_v05() -> None:
+    """Test conversion from v0.6 to v0.5."""
+    ms = Multiscale(
+        coordinateSystems=(
+            CoordinateSystem(
+                name="physical",
+                axes=(
+                    Axis(
+                        name="x",
+                        type="space",
+                        unit="meter",
+                    ),
+                    Axis(
+                        name="y",
+                        type="space",
+                        unit="meter",
+                    ),
+                ),
+            ),
+        ),
+        datasets=(
+            Dataset(
+                path="0",
+                coordinateTransformations=(
+                    Sequence(
+                        type="sequence",
+                        input=CoordinateSystemIdentifier(path="0"),
+                        output=CoordinateSystemIdentifier(name="physical"),
+                        transformations=(
+                            Scale(
+                                type="scale",
+                                scale=(2.0, -4.0),
+                            ),
+                            Translation(
+                                type="translation",
+                                translation=(5.0, 3.0),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+        metadata={"key": "value"},
+        name="my_multiscale",
+        type="my_type",
+    )
+
+    ms_target = Multiscalev05(
+        axes=(
+            Axisv05(name="x", type="space", unit="meter"),
+            Axisv05(name="y", type="space", unit="meter"),
+        ),
+        datasets=(
+            Datasetv05(
+                path="0",
+                coordinateTransformations=(
+                    VectorScale(type="scale", scale=[2.0, -4.0]),
+                    VectorTranslation(type="translation", translation=[5.0, 3.0]),
+                ),
+            ),
+        ),
+        metadata={"key": "value"},
+        name="my_multiscale",
+        type="my_type",
+    )
+
+    assert ms.to_version("0.5") == ms_target
+
 
 def test_unique_system_names() -> None:
     with pytest.raises(
@@ -452,7 +520,3 @@ def test_unique_system_names() -> None:
                 ),
             ),
         )
-
-
-if __name__ == "__main__":
-    test_from_v05()


### PR DESCRIPTION
@dstansby follow-up to #432 and #438 and the last puzzle piece that would make ozmp complete, at least for my purposes ;)

The PR adds a converter function `_to_v05` that converts everything to 0.5 with the following conditions:
- `coordinateTransformations` are omitted - there's a subset of Scale and Translation that *could* be ported, but that seems like a lot of additional complexity at this point.
- The converter doesn't check whether multiple coordinate systems exist in the scope of the `Multiscales` object - it just picks the intrinsic one and takes the `axes` from there.

Clean version of #434 .