### PR TITLE
A cleaner way to specify extra 0.6 metadata when converting multiscales

### DIFF
--- a/docs/convert.py
+++ b/docs/convert.py
@@ -1,55 +1,35 @@
 # This page explains how to convert metadata from one OME-Zarr version to another.
-#
-# ## 0.5 to 0.6
-#
-# The main addition to OME-Zarr in version 0.6 is coordinate systems.
-
 
 import zarr.storage
 from rich import print
 
-import ome_zarr_models._v06
 import ome_zarr_models.v05
+from ome_zarr_models.v05.multiscales import Extrav06Metadata
+
+# ## 0.5 to 0.6
+#
+# The main addition to OME-Zarr in version 0.6 is coordinate systems.
+
 
 zarr_group = zarr.open_group(
     "https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.5/idr0066/ExpD_chicken_embryo_MIP.ome.zarr",
     mode="r",
 )
 image_group_v05 = ome_zarr_models.v05.Image.from_zarr(zarr_group)
-print(image_group_v05.ome_attributes)
+multiscales_v05 = image_group_v05.ome_attributes.multiscales[0]
+print(multiscales_v05)
 
 # ## Metadata conversion
 #
 # ome-zarr-models-py offers a convenient way to convert multiscales metadata
-# between different ome-zarr versions without using the high-level
-# `Image` classes:
+# between different OME-Zarr versions. The `Extrav06Metadata` class can be
+# used to fill in extra information about multiscales that can be specified
+# in version 0.6:
 
-multiscale = ome_zarr_models.v05.multiscales.Multiscale.model_validate(
-    {
-        "axes": [
-            {"name": "z", "type": "space"},
-            {"name": "y", "type": "space"},
-            {"name": "x", "type": "space"},
-        ],
-        "datasets": [  # an image with a single resolution level
-            {
-                "path": "s0",
-                "coordinateTransformations": [
-                    {
-                        "type": "scale",
-                        "scale": [1, 1, 1],
-                    }
-                ],
-            }
-        ],
-        "name": "my_image",
-    }
+extra_v06_metadata = Extrav06Metadata(
+    coordinate_system_name="physical", axes_discrete=[True, True]
 )
-
-multiscale_v06 = multiscale.to_version("0.6")
-print(multiscale_v06)
-
-# This version conversion works between all currently supported versions of ome-zarr:
-
-multiscale_v04 = multiscale.to_version("0.4")
-print(multiscale_v04)
+multiscales_v06 = multiscales_v05.to_version(
+    "0.6", extra_v06_metadata=extra_v06_metadata
+)
+print(multiscales_v06)

--- a/src/ome_zarr_models/_v06/multiscales.py
+++ b/src/ome_zarr_models/_v06/multiscales.py
@@ -291,7 +291,6 @@ class Multiscale(BaseAttrs):
         - there is only 1 axis with a type that is not `space`, `time`, or `channel`
         """
         for cs in self.coordinateSystems:
-            print(cs)
             check_length(
                 [ax for ax in cs.axes if ax.type == "space"],
                 valid_lengths=[2, 3],

--- a/src/ome_zarr_models/v05/multiscales.py
+++ b/src/ome_zarr_models/v05/multiscales.py
@@ -45,10 +45,43 @@ if TYPE_CHECKING:
     from ome_zarr_models.v04.multiscales import Multiscale as MultiscaleV04
 
 
-__all__ = ["Dataset", "Multiscale"]
+__all__ = ["Dataset", "Extrav06Metadata", "Multiscale"]
 
 
 VALID_NDIM = (2, 3, 4, 5)
+
+
+class Extrav06Metadata(BaseModel):
+    """
+    Extra metadata that can optionally be added when conversion from 0.5 to 0.6.
+
+    Warnings
+    --------
+    This is experimental and subject to change.
+    """
+
+    coordinate_system_name: str = Field(
+        default="physical",
+        description="Name to give to the existing default coordinate system taken from "
+        "the 0.5 metadata.",
+    )
+
+    final_coordinate_system_name: str = Field(
+        default="intermediate",
+        description="Name given to the final coordinate system, which is only added "
+        "if the 0.5 metadata contains an additional coordinate transformation.",
+    )
+
+    axes_discrete: list[bool] | None = Field(
+        default=None,
+        description="Whether existing axes taken from the 0.5 metadata are discrete "
+        "or not. Length must match the number of axes in the 0.5 metadata.",
+    )
+    axes_long_names: list[str] | None = Field(
+        default=None,
+        description="Long names to give to axes taken from the 0.5 metadata. "
+        "Length must match the number of axes in the 0.5 metadata.",
+    )
 
 
 class Multiscale(BaseAttrs):
@@ -69,19 +102,15 @@ class Multiscale(BaseAttrs):
 
     @overload
     def to_version(
-        self,
-        version: Literal["0.6"],
-        *,
-        default_coordinate_system: str = "physical",
-        output_coordinate_system: str = "output",
+        self, version: Literal["0.6"], *, extra_v06_metadata: Extrav06Metadata | None
     ) -> MultiscaleV06:
         pass
 
     def to_version(
         self,
         version: Literal["0.4", "0.6"],
-        default_coordinate_system: str = "physical",
-        output_coordinate_system: str = "output",
+        *,
+        extra_v06_metadata: Extrav06Metadata | None = None,
     ) -> MultiscaleV04 | MultiscaleV06:
         """
         Convert this Multiscale metadata to the specified version.
@@ -94,28 +123,24 @@ class Multiscale(BaseAttrs):
         ----------
         version
             The version to convert to. Must be one of "0.4" or "0.6".
-        default_coordinate_system
-            The name of the default coordinate system to use
-            for the 0.5 -> 0.6 conversion. Defaults to "physical".
-        output_coordinate_system
-            The name of the output coordinate system to use
-            for the 0.5 -> 0.6 conversion. Defaults to "output".
-            Only used if `coordinateTransformations` are defined
-            in the 0.5 metadata.
+        extra_v06_metadata
+            Extra metadata to add when converting to version 0.6.
+
+        Warnings
+        --------
+        Converting to 0.6 is experimental and subject to change.
         """
         if version == "0.4":
             return self._to_v04()
         elif version == "0.6":
-            return self._to_v06(
-                default_coordinate_system=default_coordinate_system,
-                output_coordinate_system=output_coordinate_system,
-            )
+            if extra_v06_metadata is None:
+                extra_v06_metadata = Extrav06Metadata()
+            return self._to_v06(extra_v06_metadata=extra_v06_metadata)
         else:
             raise ValueError(f"Unsupported version conversion: 0.5 -> {version}")
 
-    def _to_v06(
-        self, default_coordinate_system: str, output_coordinate_system: str
-    ) -> MultiscaleV06:
+    def _to_v06(self, extra_v06_metadata: Extrav06Metadata) -> MultiscaleV06:
+        # TODO: implement support for handling all the options in extra_v06_metadata
         from ome_zarr_models._v06.coordinate_transforms import (
             Axis,
             CoordinateSystem,
@@ -133,7 +158,7 @@ class Multiscale(BaseAttrs):
                             update={
                                 "input": CoordinateSystemIdentifier(path=ds.path),
                                 "output": CoordinateSystemIdentifier(
-                                    name=default_coordinate_system
+                                    name=extra_v06_metadata.coordinate_system_name
                                 ),
                             }
                         ),
@@ -143,7 +168,7 @@ class Multiscale(BaseAttrs):
             ),
             coordinateSystems=(
                 CoordinateSystem(
-                    name=default_coordinate_system,
+                    name=extra_v06_metadata.coordinate_system_name,
                     axes=tuple(
                         Axis(name=ax.name, type=ax.type, unit=ax.unit)
                         for ax in self.axes
@@ -156,7 +181,7 @@ class Multiscale(BaseAttrs):
         )
         if self.coordinateTransformations is not None:
             output_cs = CoordinateSystem(
-                name=output_coordinate_system,
+                name=extra_v06_metadata.final_coordinate_system_name,
                 axes=tuple(
                     Axis(name=ax.name, type=ax.type, unit=None) for ax in self.axes
                 ),
@@ -170,10 +195,10 @@ class Multiscale(BaseAttrs):
                         ).model_copy(
                             update={
                                 "input": CoordinateSystemIdentifier(
-                                    name=default_coordinate_system
+                                    name=extra_v06_metadata.coordinate_system_name
                                 ),
                                 "output": CoordinateSystemIdentifier(
-                                    name=output_coordinate_system
+                                    name=extra_v06_metadata.final_coordinate_system_name
                                 ),
                             }
                         ),

--- a/tests/_v06/test_multiscales.py
+++ b/tests/_v06/test_multiscales.py
@@ -22,6 +22,9 @@ from ome_zarr_models.v05.multiscales import (
     Dataset as Datasetv05,
 )
 from ome_zarr_models.v05.multiscales import (
+    Extrav06Metadata,
+)
+from ome_zarr_models.v05.multiscales import (
     Multiscale as Multiscalev05,
 )
 
@@ -409,8 +412,9 @@ def test_from_v05() -> None:
     assert (
         ms.to_version(
             "0.6",
-            default_coordinate_system="physical",
-            output_coordinate_system="output",
+            extra_v06_metadata=Extrav06Metadata(
+                coordinate_system_name="physical", final_coordinate_system_name="output"
+            ),
         )
         == ms_target
     )


### PR DESCRIPTION
This grew out of me wanting to understand what extra metdata can be added to 0.6 multsicales, that can't be captured in a 0.5 multiscales.

It adds a new class, `Extrav06Metadata`, that encapsulates all the extra bits of metadata you can add.

I haven't quite finished implementing all the bits (discrete and longNames), but I wanted to open this early to see if @jo-mueller (or anyone else!) has any comments/thoughts on the design and approach here.|