### PR TITLE
Only allow 0.6dev4 as version number for 0.6 

### DIFF
--- a/src/ome_zarr_models/v06/base.py
+++ b/src/ome_zarr_models/v06/base.py
@@ -17,9 +17,8 @@ class BaseOMEAttrs(BaseAttrsv3):
     Base class for OME-Zarr 0.6 attributes.
     """
 
-    # TODO: added 0.6.dev* to allow for RFC5 testing.
-    # Remove this before final release!
-    version: Literal["0.6", "0.6.dev1", "0.6.dev2", "0.6.dev3", "0.6.dev4"]
+    # TODO: change this to 0.6 before final release!
+    version: Literal["0.6.dev4"]
 
 
 T = TypeVar("T", bound=BaseOMEAttrs)

--- a/src/ome_zarr_models/v06/image.py
+++ b/src/ome_zarr_models/v06/image.py
@@ -181,7 +181,7 @@ class Image(BaseGroupv06[ImageAttrs]):
                     multiscales=[
                         multimeta,
                     ],
-                    version="0.6dev4",
+                    version="0.6.dev4",
                 )
             ),
         )

--- a/src/ome_zarr_models/v06/image.py
+++ b/src/ome_zarr_models/v06/image.py
@@ -181,7 +181,7 @@ class Image(BaseGroupv06[ImageAttrs]):
                     multiscales=[
                         multimeta,
                     ],
-                    version="0.6",
+                    version="0.6dev4",
                 )
             ),
         )

--- a/src/ome_zarr_models/v06/scene.py
+++ b/src/ome_zarr_models/v06/scene.py
@@ -107,7 +107,7 @@ class Scene(BaseGroupv06[BaseSceneAttrs]):
                         coordinateTransformations=tuple(coord_transforms),
                         coordinateSystems=tuple(coord_systems),
                     ),
-                    version="0.6",
+                    version="0.6.dev4",
                 )
             ),
         )

--- a/src/ome_zarr_models/v06/well_types.py
+++ b/src/ome_zarr_models/v06/well_types.py
@@ -13,6 +13,6 @@ class WellMeta(ome_zarr_models.common.well_types.WellMeta):
     Metadata for a single well.
     """
 
-    version: Literal["0.6"] | None = Field(
+    version: Literal["0.6.dev4"] | None = Field(
         None, description="Version of the well specification"
     )

--- a/tests/data/examples/v06/bioformats2raw_example.json
+++ b/tests/data/examples/v06/bioformats2raw_example.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6",
+    "version": "0.6.dev4",
     "bioformats2raw.layout": 3,
     "plate": {
       "columns": [

--- a/tests/data/examples/v06/hcs_example.json
+++ b/tests/data/examples/v06/hcs_example.json
@@ -1,8 +1,8 @@
 {
   "ome": {
-    "version": "0.6",
+    "version": "0.6.dev4",
     "plate": {
-      "version": "0.6",
+      "version": "0.6.dev4",
       "acquisitions": [
         {
           "id": 1,

--- a/tests/data/examples/v06/image_example.json
+++ b/tests/data/examples/v06/image_example.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6",
+    "version": "0.6.dev4",
     "multiscales": [
       {
         "name": "example",
@@ -9,21 +9,59 @@
           {
             "name": "coord_sys0",
             "axes": [
-              { "name": "t", "type": "time", "unit": "millisecond" },
-              { "name": "c", "type": "channel" },
-              { "name": "z", "type": "space", "unit": "micrometer" },
-              { "name": "y", "type": "space", "unit": "micrometer" },
-              { "name": "x", "type": "space", "unit": "micrometer" }
+              {
+                "name": "t",
+                "type": "time",
+                "unit": "millisecond"
+              },
+              {
+                "name": "c",
+                "type": "channel"
+              },
+              {
+                "name": "z",
+                "type": "space",
+                "unit": "micrometer"
+              },
+              {
+                "name": "y",
+                "type": "space",
+                "unit": "micrometer"
+              },
+              {
+                "name": "x",
+                "type": "space",
+                "unit": "micrometer"
+              }
             ]
           },
           {
             "name": "coord_sys1",
             "axes": [
-              { "name": "t", "type": "time", "unit": "millisecond" },
-              { "name": "c", "type": "channel" },
-              { "name": "z", "type": "space", "unit": "micrometer" },
-              { "name": "y", "type": "space", "unit": "micrometer" },
-              { "name": "x", "type": "space", "unit": "micrometer" }
+              {
+                "name": "t",
+                "type": "time",
+                "unit": "millisecond"
+              },
+              {
+                "name": "c",
+                "type": "channel"
+              },
+              {
+                "name": "z",
+                "type": "space",
+                "unit": "micrometer"
+              },
+              {
+                "name": "y",
+                "type": "space",
+                "unit": "micrometer"
+              },
+              {
+                "name": "x",
+                "type": "space",
+                "unit": "micrometer"
+              }
             ]
           }
         ],
@@ -33,9 +71,19 @@
             "coordinateTransformations": [
               {
                 "type": "scale",
-                "scale": [1.0, 1.0, 0.5, 0.5, 0.5],
-                "input": { "path": "0" },
-                "output": { "name": "coord_sys0" }
+                "scale": [
+                  1.0,
+                  1.0,
+                  0.5,
+                  0.5,
+                  0.5
+                ],
+                "input": {
+                  "path": "0"
+                },
+                "output": {
+                  "name": "coord_sys0"
+                }
               }
             ]
           },
@@ -44,9 +92,19 @@
             "coordinateTransformations": [
               {
                 "type": "scale",
-                "scale": [1.0, 1.0, 1.0, 1.0, 1.0],
-                "input": { "path": "1" },
-                "output": { "name": "coord_sys0" }
+                "scale": [
+                  1.0,
+                  1.0,
+                  1.0,
+                  1.0,
+                  1.0
+                ],
+                "input": {
+                  "path": "1"
+                },
+                "output": {
+                  "name": "coord_sys0"
+                }
               }
             ]
           },
@@ -55,9 +113,19 @@
             "coordinateTransformations": [
               {
                 "type": "scale",
-                "scale": [1.0, 1.0, 2.0, 2.0, 2.0],
-                "input": { "path": "2" },
-                "output": { "name": "coord_sys0" }
+                "scale": [
+                  1.0,
+                  1.0,
+                  2.0,
+                  2.0,
+                  2.0
+                ],
+                "input": {
+                  "path": "2"
+                },
+                "output": {
+                  "name": "coord_sys0"
+                }
               }
             ]
           }
@@ -65,9 +133,19 @@
         "coordinateTransformations": [
           {
             "type": "scale",
-            "scale": [0.1, 1.0, 1.0, 1.0, 1.0],
-            "input": { "name": "coord_sys0" },
-            "output": { "name": "coord_sys1" }
+            "scale": [
+              0.1,
+              1.0,
+              1.0,
+              1.0,
+              1.0
+            ],
+            "input": {
+              "name": "coord_sys0"
+            },
+            "output": {
+              "name": "coord_sys1"
+            }
           }
         ],
         "metadata": {
@@ -75,7 +153,9 @@
           "method": "skimage.transform.pyramid_gaussian",
           "version": "0.16.1",
           "args": "[true]",
-          "kwargs": { "multichannel": true }
+          "kwargs": {
+            "multichannel": true
+          }
         }
       }
     ]

--- a/tests/data/examples/v06/image_example.json
+++ b/tests/data/examples/v06/image_example.json
@@ -71,13 +71,7 @@
             "coordinateTransformations": [
               {
                 "type": "scale",
-                "scale": [
-                  1.0,
-                  1.0,
-                  0.5,
-                  0.5,
-                  0.5
-                ],
+                "scale": [1.0, 1.0, 0.5, 0.5, 0.5],
                 "input": {
                   "path": "0"
                 },
@@ -92,13 +86,7 @@
             "coordinateTransformations": [
               {
                 "type": "scale",
-                "scale": [
-                  1.0,
-                  1.0,
-                  1.0,
-                  1.0,
-                  1.0
-                ],
+                "scale": [1.0, 1.0, 1.0, 1.0, 1.0],
                 "input": {
                   "path": "1"
                 },
@@ -113,13 +101,7 @@
             "coordinateTransformations": [
               {
                 "type": "scale",
-                "scale": [
-                  1.0,
-                  1.0,
-                  2.0,
-                  2.0,
-                  2.0
-                ],
+                "scale": [1.0, 1.0, 2.0, 2.0, 2.0],
                 "input": {
                   "path": "2"
                 },
@@ -133,13 +115,7 @@
         "coordinateTransformations": [
           {
             "type": "scale",
-            "scale": [
-              0.1,
-              1.0,
-              1.0,
-              1.0,
-              1.0
-            ],
+            "scale": [0.1, 1.0, 1.0, 1.0, 1.0],
             "input": {
               "name": "coord_sys0"
             },

--- a/tests/data/examples/v06/image_label_example.json
+++ b/tests/data/examples/v06/image_label_example.json
@@ -5,21 +5,11 @@
       "colors": [
         {
           "label-value": 0,
-          "rgba": [
-            0,
-            0,
-            128,
-            128
-          ]
+          "rgba": [0, 0, 128, 128]
         },
         {
           "label-value": 1,
-          "rgba": [
-            0,
-            128,
-            0,
-            128
-          ]
+          "rgba": [0, 128, 0, 128]
         }
       ],
       "properties": [
@@ -109,13 +99,7 @@
             "coordinateTransformations": [
               {
                 "type": "scale",
-                "scale": [
-                  1.0,
-                  1.0,
-                  0.5,
-                  0.5,
-                  0.5
-                ],
+                "scale": [1.0, 1.0, 0.5, 0.5, 0.5],
                 "input": {
                   "path": "0"
                 },
@@ -130,13 +114,7 @@
             "coordinateTransformations": [
               {
                 "type": "scale",
-                "scale": [
-                  1.0,
-                  1.0,
-                  1.0,
-                  1.0,
-                  1.0
-                ],
+                "scale": [1.0, 1.0, 1.0, 1.0, 1.0],
                 "input": {
                   "path": "1"
                 },
@@ -151,13 +129,7 @@
             "coordinateTransformations": [
               {
                 "type": "scale",
-                "scale": [
-                  1.0,
-                  1.0,
-                  2.0,
-                  2.0,
-                  2.0
-                ],
+                "scale": [1.0, 1.0, 2.0, 2.0, 2.0],
                 "input": {
                   "path": "2"
                 },
@@ -171,13 +143,7 @@
         "coordinateTransformations": [
           {
             "type": "scale",
-            "scale": [
-              0.1,
-              1.0,
-              1.0,
-              1.0,
-              1.0
-            ],
+            "scale": [0.1, 1.0, 1.0, 1.0, 1.0],
             "input": {
               "name": "coord_sys0"
             },

--- a/tests/data/examples/v06/image_label_example.json
+++ b/tests/data/examples/v06/image_label_example.json
@@ -1,15 +1,25 @@
 {
   "ome": {
-    "version": "0.6",
+    "version": "0.6.dev4",
     "image-label": {
       "colors": [
         {
           "label-value": 0,
-          "rgba": [0, 0, 128, 128]
+          "rgba": [
+            0,
+            0,
+            128,
+            128
+          ]
         },
         {
           "label-value": 1,
-          "rgba": [0, 128, 0, 128]
+          "rgba": [
+            0,
+            128,
+            0,
+            128
+          ]
         }
       ],
       "properties": [
@@ -99,9 +109,19 @@
             "coordinateTransformations": [
               {
                 "type": "scale",
-                "scale": [1.0, 1.0, 0.5, 0.5, 0.5],
-                "input": { "path": "0" },
-                "output": { "name": "coord_sys0" }
+                "scale": [
+                  1.0,
+                  1.0,
+                  0.5,
+                  0.5,
+                  0.5
+                ],
+                "input": {
+                  "path": "0"
+                },
+                "output": {
+                  "name": "coord_sys0"
+                }
               }
             ]
           },
@@ -110,9 +130,19 @@
             "coordinateTransformations": [
               {
                 "type": "scale",
-                "scale": [1.0, 1.0, 1.0, 1.0, 1.0],
-                "input": { "path": "1" },
-                "output": { "name": "coord_sys0" }
+                "scale": [
+                  1.0,
+                  1.0,
+                  1.0,
+                  1.0,
+                  1.0
+                ],
+                "input": {
+                  "path": "1"
+                },
+                "output": {
+                  "name": "coord_sys0"
+                }
               }
             ]
           },
@@ -121,9 +151,19 @@
             "coordinateTransformations": [
               {
                 "type": "scale",
-                "scale": [1.0, 1.0, 2.0, 2.0, 2.0],
-                "input": { "path": "2" },
-                "output": { "name": "coord_sys0" }
+                "scale": [
+                  1.0,
+                  1.0,
+                  2.0,
+                  2.0,
+                  2.0
+                ],
+                "input": {
+                  "path": "2"
+                },
+                "output": {
+                  "name": "coord_sys0"
+                }
               }
             ]
           }
@@ -131,9 +171,19 @@
         "coordinateTransformations": [
           {
             "type": "scale",
-            "scale": [0.1, 1.0, 1.0, 1.0, 1.0],
-            "input": { "name": "coord_sys0" },
-            "output": { "name": "coord_sys1" }
+            "scale": [
+              0.1,
+              1.0,
+              1.0,
+              1.0,
+              1.0
+            ],
+            "input": {
+              "name": "coord_sys0"
+            },
+            "output": {
+              "name": "coord_sys1"
+            }
           }
         ],
         "metadata": {

--- a/tests/data/examples/v06/labels_example.json
+++ b/tests/data/examples/v06/labels_example.json
@@ -1,6 +1,8 @@
 {
   "ome": {
-    "labels": ["cell_space_segmentation"],
-    "version": "0.6"
+    "labels": [
+      "cell_space_segmentation"
+    ],
+    "version": "0.6.dev4"
   }
 }

--- a/tests/data/examples/v06/labels_example.json
+++ b/tests/data/examples/v06/labels_example.json
@@ -1,8 +1,6 @@
 {
   "ome": {
-    "labels": [
-      "cell_space_segmentation"
-    ],
+    "labels": ["cell_space_segmentation"],
     "version": "0.6.dev4"
   }
 }

--- a/tests/data/examples/v06/labels_image_example.json
+++ b/tests/data/examples/v06/labels_image_example.json
@@ -70,13 +70,7 @@
             "coordinateTransformations": [
               {
                 "type": "scale",
-                "scale": [
-                  1.0,
-                  1.0,
-                  0.5,
-                  0.5,
-                  0.5
-                ],
+                "scale": [1.0, 1.0, 0.5, 0.5, 0.5],
                 "input": {
                   "path": "0"
                 },
@@ -90,13 +84,7 @@
         "coordinateTransformations": [
           {
             "type": "scale",
-            "scale": [
-              0.1,
-              1.0,
-              1.0,
-              1.0,
-              1.0
-            ],
+            "scale": [0.1, 1.0, 1.0, 1.0, 1.0],
             "input": {
               "name": "coord_sys0"
             },

--- a/tests/data/examples/v06/labels_image_example.json
+++ b/tests/data/examples/v06/labels_image_example.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6",
+    "version": "0.6.dev4",
     "multiscales": [
       {
         "name": "example",
@@ -70,9 +70,19 @@
             "coordinateTransformations": [
               {
                 "type": "scale",
-                "scale": [1.0, 1.0, 0.5, 0.5, 0.5],
-                "input": { "path": "0" },
-                "output": { "name": "coord_sys0" }
+                "scale": [
+                  1.0,
+                  1.0,
+                  0.5,
+                  0.5,
+                  0.5
+                ],
+                "input": {
+                  "path": "0"
+                },
+                "output": {
+                  "name": "coord_sys0"
+                }
               }
             ]
           }
@@ -80,9 +90,19 @@
         "coordinateTransformations": [
           {
             "type": "scale",
-            "scale": [0.1, 1.0, 1.0, 1.0, 1.0],
-            "input": { "name": "coord_sys0" },
-            "output": { "name": "coord_sys1" }
+            "scale": [
+              0.1,
+              1.0,
+              1.0,
+              1.0,
+              1.0
+            ],
+            "input": {
+              "name": "coord_sys0"
+            },
+            "output": {
+              "name": "coord_sys1"
+            }
           }
         ]
       }

--- a/tests/data/examples/v06/plate_example_1.json
+++ b/tests/data/examples/v06/plate_example_1.json
@@ -1,8 +1,8 @@
 {
   "ome": {
-    "version": "0.6",
+    "version": "0.6.dev4",
     "plate": {
-      "version": "0.6",
+      "version": "0.6.dev4",
       "acquisitions": [
         {
           "id": 1,

--- a/tests/data/examples/v06/plate_example_2.json
+++ b/tests/data/examples/v06/plate_example_2.json
@@ -1,8 +1,8 @@
 {
   "ome": {
-    "version": "0.6",
+    "version": "0.6.dev4",
     "plate": {
-      "version": "0.6",
+      "version": "0.6.dev4",
       "acquisitions": [
         {
           "id": 1,

--- a/tests/data/examples/v06/well_example.json
+++ b/tests/data/examples/v06/well_example.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6",
+    "version": "0.6.dev4",
     "well": {
       "images": [
         {
@@ -20,7 +20,7 @@
           "path": "3"
         }
       ],
-      "version": "0.6"
+      "version": "0.6.dev4"
     }
   }
 }

--- a/tests/v06/test_collection.py
+++ b/tests/v06/test_collection.py
@@ -356,4 +356,4 @@ def test_scene_new() -> None:
     assert scene.ome_attributes.scene.coordinateSystems[0].name == "world"
 
     # Verify version
-    assert scene.ome_attributes.version == "0.6"
+    assert scene.ome_attributes.version == "0.6.dev4"

--- a/tests/v06/test_hcs.py
+++ b/tests/v06/test_hcs.py
@@ -40,9 +40,9 @@ def test_hcs(store: Store) -> None:
                 WellInPlate(path="B/2", rowIndex=1, columnIndex=1),
                 WellInPlate(path="B/3", rowIndex=1, columnIndex=2),
             ],
-            version="0.6",
+            version="0.6.dev4",
         ),
-        version="0.6",
+        version="0.6.dev4",
     )
     well_groups = list(ome_group.well_groups)
     assert len(well_groups) == 0

--- a/tests/v06/test_image.py
+++ b/tests/v06/test_image.py
@@ -40,7 +40,7 @@ def test_image(store: Store) -> None:
     )
     ome_group = Image.from_zarr(zarr_group)
     image_attrs = ImageAttrs(
-        version="0.6",
+        version="0.6.dev4",
         multiscales=[
             Multiscale(
                 coordinateSystems=(
@@ -257,7 +257,7 @@ def test_image_new() -> None:
         ),
     }
     assert image.ome_attributes == ImageAttrs(
-        version="0.6",
+        version="0.6.dev4",
         multiscales=[
             Multiscale(
                 coordinateSystems=(

--- a/tests/v06/test_image_label.py
+++ b/tests/v06/test_image_label.py
@@ -42,7 +42,7 @@ def test_image_label(store: Store) -> None:
     )
     ome_group = ImageLabel.from_zarr(zarr_group)
     assert ome_group.attributes.ome == ImageLabelAttrs(
-        version="0.6",
+        version="0.6.dev4",
         image_label=Label(
             colors=(
                 Color(label_value=0, rgba=(0, 0, 128, 128)),

--- a/tests/v06/test_labels.py
+++ b/tests/v06/test_labels.py
@@ -25,7 +25,7 @@ def test_labels(store: Store) -> None:
 
     ome_group = Labels.from_zarr(zarr_group)
     assert ome_group.attributes.ome == LabelsAttrs(
-        labels=["cell_space_segmentation"], version="0.6"
+        labels=["cell_space_segmentation"], version="0.6.dev4"
     )
 
 

--- a/tests/v06/test_plate.py
+++ b/tests/v06/test_plate.py
@@ -45,7 +45,7 @@ def test_example_plate_json(store: Store) -> None:
             WellInPlate(path="B/2", rowIndex=1, columnIndex=1),
             WellInPlate(path="B/3", rowIndex=1, columnIndex=2),
         ],
-        version="0.6",
+        version="0.6.dev4",
     )
 
 
@@ -95,7 +95,7 @@ def test_example_plate_json_2(store: Store) -> None:
             WellInPlate(path="C/5", rowIndex=2, columnIndex=4),
             WellInPlate(path="D/7", rowIndex=3, columnIndex=6),
         ],
-        version="0.6",
+        version="0.6.dev4",
     )
 
 

--- a/tests/v06/test_well.py
+++ b/tests/v06/test_well.py
@@ -9,7 +9,7 @@ def test_well(store: Store) -> None:
     zarr_group = json_to_zarr_group(json_fname="well_example.json", store=store)
     ome_group = Well.from_zarr(zarr_group)
     assert ome_group.attributes.ome == WellAttrs(
-        version="0.6",
+        version="0.6.dev4",
         well=WellMeta(
             images=[
                 WellImage(path="0", acquisition=1),
@@ -17,7 +17,7 @@ def test_well(store: Store) -> None:
                 WellImage(path="2", acquisition=2),
                 WellImage(path="3", acquisition=2),
             ],
-            version="0.6",
+            version="0.6.dev4",
         ),
     )
 
@@ -30,7 +30,7 @@ def test_get_paths() -> None:
             WellImage(path="2", acquisition=2),
             WellImage(path="3", acquisition=2),
         ],
-        version="0.6",
+        version="0.6.dev4",
     )
 
     assert well.get_acquisition_paths() == {1: ["0", "1"], 2: ["2", "3"]}


### PR DESCRIPTION
Since there have been major changes throughout 0.6 development, pin the allowed version numbers to an exact development version. @jo-mueller what do you think? This prevents loading older or newer data, but I think that's good because we don't want user (or developer) confusion around exactly what version of the specification ome-zarr-models represents.

Depends on https://github.com/jo-mueller/ngff-rfc5-coordinate-transformation-examples/pull/45