### PR TITLE
Move some conversion logic on to axes and multiscales classes

### DIFF
--- a/src/ome_zarr_models/v04/axes.py
+++ b/src/ome_zarr_models/v04/axes.py
@@ -1,9 +1,12 @@
 from collections.abc import Sequence
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import JsonValue
 
 from ome_zarr_models.base import BaseAttrs
+
+if TYPE_CHECKING:
+    from ome_zarr_models.v05.axes import Axis as AxisV05
 
 __all__ = ["Axes", "Axis", "AxisType"]
 
@@ -21,6 +24,16 @@ class Axis(BaseAttrs):
     type: str | None = None
     # Unit probably intended to be str, but the spec doesn't explicitly specify
     unit: str | JsonValue | None = None
+
+    def _to_v05(self) -> "AxisV05":
+        from ome_zarr_models.v05.axes import Axis as AxisV05
+
+        if isinstance(self.name, str) or self.name is None:
+            return AxisV05(name=self.name, type=self.type, unit=self.unit)
+        else:
+            raise RuntimeError(
+                "Can only convert Axes that have names that are strings or None"
+            )
 
 
 Axes = Sequence[Axis]

--- a/src/ome_zarr_models/v04/multiscales.py
+++ b/src/ome_zarr_models/v04/multiscales.py
@@ -35,6 +35,7 @@ from ome_zarr_models.v04.axes import Axes
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from ome_zarr_models.v05.multiscales import Dataset as DatasetV05
     from ome_zarr_models.v05.multiscales import Multiscale as MultiscaleV05
 
 
@@ -70,25 +71,11 @@ class Multiscale(BaseAttrs):
             raise ValueError(f"Unsupported version conversion: 0.4 -> {version}")
 
     def _to_v05(self) -> MultiscaleV05:
-        from ome_zarr_models.v05.axes import Axis as AxisV05
-        from ome_zarr_models.v05.multiscales import (
-            Dataset as DatasetV05,
-        )
-        from ome_zarr_models.v05.multiscales import (
-            Multiscale as MultiscaleV05,
-        )
+        from ome_zarr_models.v05.multiscales import Multiscale as MultiscaleV05
 
         return MultiscaleV05(
-            axes=tuple(
-                [AxisV05(name=a.name, type=a.type, unit=a.unit) for a in self.axes]
-            ),
-            datasets=tuple(
-                DatasetV05(
-                    path=d.path,
-                    coordinateTransformations=d.coordinateTransformations,
-                )
-                for d in self.datasets
-            ),
+            axes=tuple([a._to_v05() for a in self.axes]),
+            datasets=tuple([d._to_v05() for d in self.datasets]),
             coordinateTransformations=self.coordinateTransformations,
             metadata=self.metadata,
             name=self.name,
@@ -343,3 +330,11 @@ class Dataset(BaseAttrs):
             )
             raise ValueError(msg)
         return transforms
+
+    def _to_v05(self) -> DatasetV05:
+        from ome_zarr_models.v05.multiscales import Dataset as DatasetV05
+
+        return DatasetV05(
+            path=self.path,
+            coordinateTransformations=self.coordinateTransformations,
+        )

--- a/src/ome_zarr_models/v05/axes.py
+++ b/src/ome_zarr_models/v05/axes.py
@@ -1,9 +1,13 @@
 from collections.abc import Sequence
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import JsonValue
 
 from ome_zarr_models.base import BaseAttrs
+
+if TYPE_CHECKING:
+    from ome_zarr_models.v04.axes import Axis as AxisV04
+    from ome_zarr_models.v06.coordinate_transforms import Axis as AxisV06
 
 __all__ = ["Axes", "Axis", "AxisType"]
 
@@ -23,6 +27,16 @@ class Axis(BaseAttrs):
     type: str | None = None
     # Unit probably intended to be str, but the spec doesn't explicitly specify
     unit: str | JsonValue | None = None
+
+    def _to_v04(self) -> "AxisV04":
+        from ome_zarr_models.v04.axes import Axis as AxisV04
+
+        return AxisV04(name=self.name, type=self.type, unit=self.unit)
+
+    def _to_v06(self) -> "AxisV06":
+        from ome_zarr_models.v06.coordinate_transforms import Axis as AxisV06
+
+        return AxisV06(name=self.name, type=self.type, unit=self.unit)
 
 
 Axes = Sequence[Axis]

--- a/src/ome_zarr_models/v05/multiscales.py
+++ b/src/ome_zarr_models/v05/multiscales.py
@@ -35,15 +35,12 @@ from ome_zarr_models.v05.axes import Axes
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from ome_zarr_models.v04.multiscales import Dataset as DatasetV04
     from ome_zarr_models.v04.multiscales import Multiscale as MultiscaleV04
-    from ome_zarr_models.v06.coordinate_transforms import (
-        Scale as ScaleV06,
-    )
-    from ome_zarr_models.v06.coordinate_transforms import (
-        Sequence as SequenceV06,
-    )
+    from ome_zarr_models.v06.coordinate_transforms import Scale as ScaleV06
+    from ome_zarr_models.v06.coordinate_transforms import Sequence as SequenceV06
+    from ome_zarr_models.v06.multiscales import Dataset as DatasetV06
     from ome_zarr_models.v06.multiscales import Multiscale as MultiscaleV06
-
 
 __all__ = ["Dataset", "Multiscale"]
 
@@ -121,33 +118,17 @@ class Multiscale(BaseAttrs):
             CoordinateSystem,
             CoordinateSystemIdentifier,
         )
-        from ome_zarr_models.v06.multiscales import Dataset as DatasetV06
         from ome_zarr_models.v06.multiscales import Multiscale as MultiscaleV06
 
         ms_v06 = MultiscaleV06(
             datasets=tuple(
-                DatasetV06(
-                    path=ds.path,
-                    coordinateTransformations=(
-                        _v05_transform_to_v06(ds.coordinateTransformations).model_copy(
-                            update={
-                                "input": CoordinateSystemIdentifier(path=ds.path),
-                                "output": CoordinateSystemIdentifier(
-                                    name=default_coordinate_system
-                                ),
-                            }
-                        ),
-                    ),
-                )
+                ds._to_v06(default_coordinate_system_name=default_coordinate_system)
                 for ds in self.datasets
             ),
             coordinateSystems=(
                 CoordinateSystem(
                     name=default_coordinate_system,
-                    axes=tuple(
-                        Axis(name=ax.name, type=ax.type, unit=ax.unit)
-                        for ax in self.axes
-                    ),
+                    axes=tuple(ax._to_v06() for ax in self.axes),
                 ),
             ),
             metadata=self.metadata,
@@ -187,21 +168,11 @@ class Multiscale(BaseAttrs):
         return ms_v06
 
     def _to_v04(self) -> MultiscaleV04:
-        from ome_zarr_models.v04.axes import Axis as AxisV04
-        from ome_zarr_models.v04.multiscales import Dataset as DatasetV04
         from ome_zarr_models.v04.multiscales import Multiscale as MultiscaleV04
 
         return MultiscaleV04(
-            axes=tuple(
-                [AxisV04(name=a.name, type=a.type, unit=a.unit) for a in self.axes]
-            ),
-            datasets=tuple(
-                DatasetV04(
-                    path=d.path,
-                    coordinateTransformations=d.coordinateTransformations,
-                )
-                for d in self.datasets
-            ),
+            axes=tuple([ax._to_v04() for ax in self.axes]),
+            datasets=tuple([d._to_v04() for d in self.datasets]),
             coordinateTransformations=self.coordinateTransformations,
             metadata=self.metadata,
             name=self.name,
@@ -456,6 +427,32 @@ class Dataset(BaseAttrs):
             )
             raise ValueError(msg)
         return transforms
+
+    def _to_v04(self) -> DatasetV04:
+        from ome_zarr_models.v04.multiscales import Dataset as DatasetV04
+
+        return DatasetV04(
+            path=self.path,
+            coordinateTransformations=self.coordinateTransformations,
+        )
+
+    def _to_v06(self, *, default_coordinate_system_name: str) -> DatasetV06:
+        from ome_zarr_models.v06.coordinate_transforms import CoordinateSystemIdentifier
+        from ome_zarr_models.v06.multiscales import Dataset as DatasetV06
+
+        return DatasetV06(
+            path=self.path,
+            coordinateTransformations=(
+                _v05_transform_to_v06(self.coordinateTransformations).model_copy(
+                    update={
+                        "input": CoordinateSystemIdentifier(path=self.path),
+                        "output": CoordinateSystemIdentifier(
+                            name=default_coordinate_system_name
+                        ),
+                    }
+                ),
+            ),
+        )
 
 
 def _v05_transform_to_v06(transform: ValidTransform) -> ScaleV06 | SequenceV06:

--- a/src/ome_zarr_models/v06/coordinate_transforms.py
+++ b/src/ome_zarr_models/v06/coordinate_transforms.py
@@ -1,12 +1,15 @@
 import typing
 from abc import ABC, abstractmethod
-from typing import Annotated, Literal, Self, TypeVar
+from typing import TYPE_CHECKING, Annotated, Literal, Self, TypeVar
 
 import numpy as np
 from pydantic import Field, JsonValue, field_validator, model_validator
 
 from ome_zarr_models.base import BaseAttrs
 from ome_zarr_models.common.validation import unique_items_validator
+
+if TYPE_CHECKING:
+    from ome_zarr_models.v05.axes import Axis as Axisv05
 
 
 class NoAffineError(RuntimeError):
@@ -37,6 +40,11 @@ class Axis(BaseAttrs):
     # Unit probably intended to be str, but the spec doesn't explicitly specify
     unit: str | JsonValue | None = Field(default=None, description="Axis units.")
     longName: str | None = Field(default=None, description="Longer name for axis..")
+
+    def _to_v05(self) -> "Axisv05":
+        from ome_zarr_models.v05.axes import Axis as Axisv05
+
+        return Axisv05(name=self.name, type=self.type, unit=self.unit)
 
 
 class CoordinateSystem(BaseAttrs):

--- a/src/ome_zarr_models/v06/multiscales.py
+++ b/src/ome_zarr_models/v06/multiscales.py
@@ -27,6 +27,7 @@ from ome_zarr_models.v06.coordinate_transforms import (
 
 if TYPE_CHECKING:
     from ome_zarr_models.v04.multiscales import Multiscale as Multiscalev04
+    from ome_zarr_models.v05.multiscales import Dataset as Datasetv05
     from ome_zarr_models.v05.multiscales import Multiscale as Multiscalev05
 
 __all__ = ["Dataset", "Multiscale"]
@@ -78,64 +79,10 @@ class Multiscale(BaseAttrs):
             raise ValueError(f"Unsupported version: {version}")
 
     def _to_v05(self) -> Multiscalev05:
-        from ome_zarr_models.common.coordinate_transformations import (
-            ValidTransform,
-        )
-        from ome_zarr_models.v05.axes import Axis as Axisv05
-        from ome_zarr_models.v05.coordinate_transformations import (
-            VectorScale,
-            VectorTranslation,
-        )
-        from ome_zarr_models.v05.multiscales import (
-            Dataset as Datasetv05,
-        )
-        from ome_zarr_models.v05.multiscales import (
-            Multiscale as Multiscalev05,
-        )
+        from ome_zarr_models.v05.multiscales import Multiscale as Multiscalev05
 
-        intrinsic_cs = self.intrinsic_coordinate_system
-        axes = tuple(
-            [
-                Axisv05(name=axis.name, type=axis.type, unit=axis.unit)
-                for axis in intrinsic_cs.axes
-            ]
-        )
-
-        datasets = []
-        for ds in self.datasets:
-            scale_transform: VectorScale | None = None
-            translation_transform: VectorTranslation | None = None
-
-            for tf in ds.coordinateTransformations:
-                if isinstance(tf, Scale):
-                    scale_transform = VectorScale(type="scale", scale=list(tf.scale))
-                elif isinstance(tf, Sequence):
-                    for sub_tf in tf.transformations:
-                        if isinstance(sub_tf, Scale):
-                            scale_transform = VectorScale(
-                                type="scale", scale=list(sub_tf.scale)
-                            )
-                        elif isinstance(sub_tf, Translation):
-                            translation_transform = VectorTranslation(
-                                type="translation", translation=list(sub_tf.translation)
-                            )
-                        else:
-                            raise ValueError(
-                                f"Unsupported transform type: {type(sub_tf)}"
-                            )
-
-            if scale_transform is None:
-                raise ValueError("No scale transform found")
-
-            coord_transforms: ValidTransform
-            if translation_transform is not None:
-                coord_transforms = (scale_transform, translation_transform)
-            else:
-                coord_transforms = (scale_transform,)
-
-            datasets.append(
-                Datasetv05(path=ds.path, coordinateTransformations=coord_transforms)
-            )
+        axes = [axis._to_v05() for axis in self.intrinsic_coordinate_system.axes]
+        datasets = [ds._to_v05() for ds in self.datasets]
 
         if self.coordinateTransformations is not None:
             warnings.warn(
@@ -150,7 +97,7 @@ class Multiscale(BaseAttrs):
             name=self.name,
             type=self.type,
             metadata=self.metadata,
-            axes=axes,
+            axes=tuple(axes),
             datasets=tuple(datasets),
         )
         return new_ms
@@ -574,3 +521,41 @@ class Dataset(BaseAttrs):
                 f"Got {scale.ndim} and {translation.ndim}."
             )
         return transforms
+
+    def _to_v05(self) -> Datasetv05:
+        from ome_zarr_models.common.coordinate_transformations import ValidTransform
+        from ome_zarr_models.v05.coordinate_transformations import (
+            VectorScale,
+            VectorTranslation,
+        )
+        from ome_zarr_models.v05.multiscales import Dataset as Datasetv05
+
+        scale_transform: VectorScale | None = None
+        translation_transform: VectorTranslation | None = None
+
+        for tf in self.coordinateTransformations:
+            if isinstance(tf, Scale):
+                scale_transform = VectorScale(type="scale", scale=list(tf.scale))
+            elif isinstance(tf, Sequence):
+                for sub_tf in tf.transformations:
+                    if isinstance(sub_tf, Scale):
+                        scale_transform = VectorScale(
+                            type="scale", scale=list(sub_tf.scale)
+                        )
+                    elif isinstance(sub_tf, Translation):
+                        translation_transform = VectorTranslation(
+                            type="translation", translation=list(sub_tf.translation)
+                        )
+                    else:
+                        raise ValueError(f"Unsupported transform type: {type(sub_tf)}")
+
+        if scale_transform is None:
+            raise ValueError("No scale transform found")
+
+        coord_transforms: ValidTransform
+        if translation_transform is not None:
+            coord_transforms = (scale_transform, translation_transform)
+        else:
+            coord_transforms = (scale_transform,)
+
+        return Datasetv05(path=self.path, coordinateTransformations=coord_transforms)


### PR DESCRIPTION
This is just a code structure cleanup. By splitting up the conversion code it makes it a bit cleaner and easier to follow, and easier to spot issues when converting between versions. By doing this I spotted that when converting an axis from 0.4 to 0.5 we have to check the type of the `name` field.