### PR TITLE
Add version conversion method for `ImageAttrs`

### DIFF
--- a/docs/convert.py
+++ b/docs/convert.py
@@ -1,15 +1,17 @@
 # This page explains how to convert metadata from one OME-Zarr version to another.
 #
-# ## 0.5 to 0.6
-#
-# The main addition to OME-Zarr in version 0.6 is coordinate systems for images.
-
 
 import zarr.storage
 from rich import print
 
 import ome_zarr_models.v05
 import ome_zarr_models.v06
+
+# ## 0.5 to 0.6
+#
+# The main addition to OME-Zarr in version 0.6 is coordinate systems for images.
+# This example shows how to convert OME-Zarr 0.5 image metadata to OME-Zarr 0.6.
+
 
 zarr_group = zarr.open_group(
     "https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.5/idr0066/ExpD_chicken_embryo_MIP.ome.zarr",
@@ -23,6 +25,15 @@ image_attributes_v06 = image_attributes_v05.to_version(
     "0.6", default_cs_name="intrinsic"
 )
 print(image_attributes_v06)
+
+# With the new metadata, we can create a full Image model.
+# This Image can then be saved using the `to_zarr()` method.
+# Because it does not contain any array data or metadata, the
+# array data will need to be manually copied from the old 0.5
+# group to the new 0.6 group.
+
+image_v06 = ome_zarr_models.v06.Image(ome=image_attributes_v06)
+# image_v06.to_zarr(...)
 
 # The 0.6 specification provides some new fields over the 0.5 version,
 # such as the `coordinateSystems` field,

--- a/docs/convert.py
+++ b/docs/convert.py
@@ -45,11 +45,10 @@ image_v06 = ome_zarr_models.v06.Image(
 # (i.e., the `name` of the default coordinate system is set to "physical").
 # However, these fields can manually be filled or edited after conversion if desired:
 
-metadata = multiscale_v06.model_dump()
-metadata["coordinateSystems"][0]["axes"][0]["longName"] = "OpticalAxis"
-
-# And we can update the multiscale metadata model with the edits:
-
-edited_multiscale_v06 = ome_zarr_models.v06.multiscales.Multiscale.model_validate(
-    metadata
+image_metadata_v06 = image_v06.ome_attributes.model_dump()
+image_metadata_v06["multiscales"][0]["coordinateSystems"][0]["axes"][0]["longName"] = (
+    "OpticalAxis"
+)
+image_attributes_v06 = ome_zarr_models.v06.image.ImageAttrs.model_validate(
+    image_metadata_v06
 )

--- a/docs/convert.py
+++ b/docs/convert.py
@@ -32,7 +32,9 @@ print(image_attributes_v06)
 # array data will need to be manually copied from the old 0.5
 # group to the new 0.6 group.
 
-image_v06 = ome_zarr_models.v06.Image(attributes={"ome": image_attributes_v06})
+image_v06 = ome_zarr_models.v06.Image(
+    members=image_group_v05.members, attributes={"ome": image_attributes_v06}
+)
 # image_v06.to_zarr(...)
 
 # The 0.6 specification provides some new fields over the 0.5 version,

--- a/docs/convert.py
+++ b/docs/convert.py
@@ -2,7 +2,7 @@
 #
 # ## 0.5 to 0.6
 #
-# The main addition to OME-Zarr in version 0.6 is coordinate systems.
+# The main addition to OME-Zarr in version 0.6 is coordinate systems for images.
 
 
 import zarr.storage
@@ -16,43 +16,13 @@ zarr_group = zarr.open_group(
     mode="r",
 )
 image_group_v05 = ome_zarr_models.v05.Image.from_zarr(zarr_group)
-print(image_group_v05.ome_attributes)
+image_attributes_v05 = image_group_v05.ome_attributes
+print(image_attributes_v05)
 
-# ## Metadata conversion
-#
-# ome-zarr-models-py offers a convenient way to convert multiscales metadata
-# between different ome-zarr versions without using the high-level
-# `Image` classes:
-
-multiscale = ome_zarr_models.v05.multiscales.Multiscale.model_validate(
-    {
-        "axes": [
-            {"name": "z", "type": "space"},
-            {"name": "y", "type": "space"},
-            {"name": "x", "type": "space"},
-        ],
-        "datasets": [  # an image with a single resolution level
-            {
-                "path": "s0",
-                "coordinateTransformations": [
-                    {
-                        "type": "scale",
-                        "scale": [1, 1, 1],
-                    }
-                ],
-            }
-        ],
-        "name": "my_image",
-    }
+image_attributes_v06 = image_attributes_v05.to_version(
+    "0.6", default_coordinate_system="intrinsic"
 )
-
-multiscale_v06 = multiscale.to_version("0.6")
-print(multiscale_v06)
-
-# This version conversion works between all currently supported versions of ome-zarr:
-
-multiscale_v04 = multiscale.to_version("0.4")
-print(multiscale_v04)
+print(image_attributes_v06)
 
 # The 0.6 specification provides some new fields over the 0.5 version,
 # such as the `coordinateSystems` field,

--- a/docs/convert.py
+++ b/docs/convert.py
@@ -11,7 +11,8 @@ import ome_zarr_models.v06
 #
 # The main addition to OME-Zarr in version 0.6 is coordinate systems for images.
 # This example shows how to convert OME-Zarr 0.5 image metadata to OME-Zarr 0.6.
-
+#
+# To start we'll open a OME-Zarr 0.5 image, and extract the OME-Zarr image metadata.
 
 zarr_group = zarr.open_group(
     "https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.5/idr0066/ExpD_chicken_embryo_MIP.ome.zarr",
@@ -20,6 +21,9 @@ zarr_group = zarr.open_group(
 image_group_v05 = ome_zarr_models.v05.Image.from_zarr(zarr_group)
 image_attributes_v05 = image_group_v05.ome_attributes
 print(image_attributes_v05)
+
+
+# Next we'll convert this metadata to version 0.6.
 
 image_attributes_v06 = image_attributes_v05.to_version(
     "0.6", default_cs_name="intrinsic"
@@ -43,7 +47,9 @@ image_v06 = ome_zarr_models.v06.Image(
 #
 # In the process of conversion, these new fields are provided with default values
 # (i.e., the `name` of the default coordinate system is set to "physical").
-# However, these fields can manually be filled or edited after conversion if desired:
+# However, these fields can manually be filled or edited after conversion if desired.
+# The easiest way to do this is convert the model to a dictionary, edit it,
+# and then read it in again to a model (which will validate the new metadata)
 
 image_metadata_v06 = image_v06.ome_attributes.model_dump()
 image_metadata_v06["multiscales"][0]["coordinateSystems"][0]["axes"][0]["longName"] = (

--- a/docs/convert.py
+++ b/docs/convert.py
@@ -32,7 +32,7 @@ print(image_attributes_v06)
 # array data will need to be manually copied from the old 0.5
 # group to the new 0.6 group.
 
-image_v06 = ome_zarr_models.v06.Image(ome=image_attributes_v06)
+image_v06 = ome_zarr_models.v06.Image(attributes={"ome": image_attributes_v06})
 # image_v06.to_zarr(...)
 
 # The 0.6 specification provides some new fields over the 0.5 version,

--- a/docs/convert.py
+++ b/docs/convert.py
@@ -20,7 +20,7 @@ image_attributes_v05 = image_group_v05.ome_attributes
 print(image_attributes_v05)
 
 image_attributes_v06 = image_attributes_v05.to_version(
-    "0.6", default_coordinate_system="intrinsic"
+    "0.6", default_cs_name="intrinsic"
 )
 print(image_attributes_v06)
 

--- a/src/ome_zarr_models/v05/image.py
+++ b/src/ome_zarr_models/v05/image.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import Self
+from typing import TYPE_CHECKING, Literal, Self
 
 # Import needed for pydantic type resolution
 import pydantic_zarr  # noqa: F401
@@ -14,6 +14,9 @@ from ome_zarr_models.v05.axes import Axis
 from ome_zarr_models.v05.base import BaseGroupv05, BaseOMEAttrs, BaseZarrAttrs
 from ome_zarr_models.v05.labels import Labels
 from ome_zarr_models.v05.multiscales import Dataset, Multiscale
+
+if TYPE_CHECKING:
+    from ome_zarr_models.v06.image import ImageAttrs as ImageAttrsV06
 
 __all__ = ["Image", "ImageAttrs"]
 
@@ -38,6 +41,63 @@ class ImageAttrs(BaseOMEAttrs):
 
     def get_optional_group_paths(self) -> dict[str, type[Labels]]:  # type: ignore[override]
         return {"labels": Labels}
+
+    def to_version(
+        self,
+        version: Literal["0.6"],
+        *,
+        default_coordinate_system: str = "physical",
+        output_coordinate_system: str = "output",
+    ) -> "ImageAttrsV06":
+        """
+        Convert these Image Attributes metadata to the specified version.
+
+        Currently supported conversions are
+        - 0.5 -> 0.6
+
+        Parameters
+        ----------
+        version
+            The version to convert to. Must be "0.6".
+        default_coordinate_system
+            The name of the default coordinate system to use
+            for the 0.5 -> 0.6 conversion. Defaults to "physical".
+        output_coordinate_system
+            The name of the output coordinate system to use
+            for the 0.5 -> 0.6 conversion. Defaults to "output".
+            Only used if `coordinateTransformations` are defined
+            in the 0.5 metadata.
+
+
+        Notes
+        -----
+        If there is more than one multiscale, the same default coordinate system names
+        are applied to each multiscale. If you need them to be different, edit them
+        manually after the conversion.
+        """
+        if version == "0.6":
+            return self._to_v06()
+
+        raise ValueError(f"Unsupported version conversion: 0.5 -> {version}")
+
+    def _to_v06(
+        self,
+        default_coordinate_system: str = "physical",
+        output_coordinate_system: str = "output",
+    ) -> "ImageAttrsV06":
+        from ome_zarr_models.v06.image import ImageAttrs as ImageAttrsV06
+
+        return ImageAttrsV06(
+            version="0.6.dev4",
+            multiscales=[
+                m.to_version(
+                    "0.6",
+                    default_coordinate_system=default_coordinate_system,
+                    output_coordinate_system=output_coordinate_system,
+                )
+                for m in self.multiscales
+            ],
+        )
 
 
 class Image(BaseGroupv05[ImageAttrs]):

--- a/src/ome_zarr_models/v05/image.py
+++ b/src/ome_zarr_models/v05/image.py
@@ -46,8 +46,8 @@ class ImageAttrs(BaseOMEAttrs):
         self,
         version: Literal["0.6"],
         *,
-        default_coordinate_system: str = "physical",
-        output_coordinate_system: str = "output",
+        default_cs_name: str = "physical",
+        output_cs_name: str = "output",
     ) -> "ImageAttrsV06":
         """
         Convert these Image Attributes metadata to the specified version.
@@ -59,10 +59,10 @@ class ImageAttrs(BaseOMEAttrs):
         ----------
         version
             The version to convert to. Must be "0.6".
-        default_coordinate_system
+        default_cs_name
             The name of the default coordinate system to use
             for the 0.5 -> 0.6 conversion. Defaults to "physical".
-        output_coordinate_system
+        output_cs_name
             The name of the output coordinate system to use
             for the 0.5 -> 0.6 conversion. Defaults to "output".
             Only used if `coordinateTransformations` are defined
@@ -76,14 +76,17 @@ class ImageAttrs(BaseOMEAttrs):
         manually after the conversion.
         """
         if version == "0.6":
-            return self._to_v06()
+            return self._to_v06(
+                output_cs_name=output_cs_name, default_cs_name=default_cs_name
+            )
 
         raise ValueError(f"Unsupported version conversion: 0.5 -> {version}")
 
     def _to_v06(
         self,
-        default_coordinate_system: str = "physical",
-        output_coordinate_system: str = "output",
+        *,
+        default_cs_name: str = "physical",
+        output_cs_name: str = "output",
     ) -> "ImageAttrsV06":
         from ome_zarr_models.v06.image import ImageAttrs as ImageAttrsV06
 
@@ -92,8 +95,8 @@ class ImageAttrs(BaseOMEAttrs):
             multiscales=[
                 m.to_version(
                     "0.6",
-                    default_coordinate_system=default_coordinate_system,
-                    output_coordinate_system=output_coordinate_system,
+                    default_cs_name=default_cs_name,
+                    output_cs_name=output_cs_name,
                 )
                 for m in self.multiscales
             ],

--- a/src/ome_zarr_models/v05/multiscales.py
+++ b/src/ome_zarr_models/v05/multiscales.py
@@ -69,16 +69,17 @@ class Multiscale(BaseAttrs):
         self,
         version: Literal["0.6"],
         *,
-        default_coordinate_system: str = "physical",
-        output_coordinate_system: str = "output",
+        default_cs_name: str = "physical",
+        output_cs_name: str = "output",
     ) -> MultiscaleV06:
         pass
 
     def to_version(
         self,
         version: Literal["0.4", "0.6"],
-        default_coordinate_system: str = "physical",
-        output_coordinate_system: str = "output",
+        *,
+        default_cs_name: str = "physical",
+        output_cs_name: str = "output",
     ) -> MultiscaleV04 | MultiscaleV06:
         """
         Convert this Multiscale metadata to the specified version.
@@ -91,10 +92,10 @@ class Multiscale(BaseAttrs):
         ----------
         version
             The version to convert to. Must be one of "0.4" or "0.6".
-        default_coordinate_system
+        default_cs_name
             The name of the default coordinate system to use
             for the 0.5 -> 0.6 conversion. Defaults to "physical".
-        output_coordinate_system
+        output_cs_name
             The name of the output coordinate system to use
             for the 0.5 -> 0.6 conversion. Defaults to "output".
             Only used if `coordinateTransformations` are defined
@@ -104,15 +105,13 @@ class Multiscale(BaseAttrs):
             return self._to_v04()
         elif version == "0.6":
             return self._to_v06(
-                default_coordinate_system=default_coordinate_system,
-                output_coordinate_system=output_coordinate_system,
+                default_cs_name=default_cs_name,
+                output_cs_name=output_cs_name,
             )
         else:
             raise ValueError(f"Unsupported version conversion: 0.5 -> {version}")
 
-    def _to_v06(
-        self, default_coordinate_system: str, output_coordinate_system: str
-    ) -> MultiscaleV06:
+    def _to_v06(self, *, default_cs_name: str, output_cs_name: str) -> MultiscaleV06:
         from ome_zarr_models.v06.coordinate_transforms import (
             Axis,
             CoordinateSystem,
@@ -122,12 +121,11 @@ class Multiscale(BaseAttrs):
 
         ms_v06 = MultiscaleV06(
             datasets=tuple(
-                ds._to_v06(default_coordinate_system_name=default_coordinate_system)
-                for ds in self.datasets
+                ds._to_v06(default_cs_name=default_cs_name) for ds in self.datasets
             ),
             coordinateSystems=(
                 CoordinateSystem(
-                    name=default_coordinate_system,
+                    name=default_cs_name,
                     axes=tuple(ax._to_v06() for ax in self.axes),
                 ),
             ),
@@ -137,7 +135,7 @@ class Multiscale(BaseAttrs):
         )
         if self.coordinateTransformations is not None:
             output_cs = CoordinateSystem(
-                name=output_coordinate_system,
+                name=output_cs_name,
                 axes=tuple(
                     Axis(name=ax.name, type=ax.type, unit=None) for ax in self.axes
                 ),
@@ -151,10 +149,10 @@ class Multiscale(BaseAttrs):
                         ).model_copy(
                             update={
                                 "input": CoordinateSystemIdentifier(
-                                    name=default_coordinate_system
+                                    name=default_cs_name
                                 ),
                                 "output": CoordinateSystemIdentifier(
-                                    name=output_coordinate_system
+                                    name=output_cs_name
                                 ),
                             }
                         ),
@@ -436,7 +434,7 @@ class Dataset(BaseAttrs):
             coordinateTransformations=self.coordinateTransformations,
         )
 
-    def _to_v06(self, *, default_coordinate_system_name: str) -> DatasetV06:
+    def _to_v06(self, *, default_cs_name: str) -> DatasetV06:
         from ome_zarr_models.v06.coordinate_transforms import CoordinateSystemIdentifier
         from ome_zarr_models.v06.multiscales import Dataset as DatasetV06
 
@@ -446,9 +444,7 @@ class Dataset(BaseAttrs):
                 _v05_transform_to_v06(self.coordinateTransformations).model_copy(
                     update={
                         "input": CoordinateSystemIdentifier(path=self.path),
-                        "output": CoordinateSystemIdentifier(
-                            name=default_coordinate_system_name
-                        ),
+                        "output": CoordinateSystemIdentifier(name=default_cs_name),
                     }
                 ),
             ),

--- a/tests/v05/test_image.py
+++ b/tests/v05/test_image.py
@@ -252,7 +252,7 @@ def test_image_with_labels_mismatch_multiscales(store: Store) -> None:
         Image.from_zarr(zarr_group)
 
 
-def test_image_convert_v06():
+def test_image_convert_v06() -> None:
     from ome_zarr_models.v06.coordinate_transforms import (
         Axis as AxisV06,
     )
@@ -413,7 +413,9 @@ def test_image_convert_v06():
                     ),
                 ),
                 metadata={
-                    "description": "the fields in metadata depend on the downscaling implementation. Here, the parameters passed to the skimage function are given",
+                    "description": "the fields in metadata depend on the downscaling"
+                    " implementation. Here, the parameters passed to the "
+                    "skimage function are given",
                     "method": "skimage.transform.pyramid_gaussian",
                     "version": "0.16.1",
                     "args": "[true]",

--- a/tests/v05/test_image.py
+++ b/tests/v05/test_image.py
@@ -4,6 +4,7 @@ import pytest
 import zarr
 from pydantic import ValidationError
 from zarr.abc.store import Store
+from zarr.storage import MemoryStore
 
 from ome_zarr_models.v05.axes import Axis
 from ome_zarr_models.v05.coordinate_transformations import VectorScale
@@ -249,3 +250,177 @@ def test_image_with_labels_mismatch_multiscales(store: Store) -> None:
         ),
     ):
         Image.from_zarr(zarr_group)
+
+
+def test_image_convert_v06():
+    from ome_zarr_models.v06.coordinate_transforms import (
+        Axis as AxisV06,
+    )
+    from ome_zarr_models.v06.coordinate_transforms import (
+        CoordinateSystem,
+        CoordinateSystemIdentifier,
+        Scale,
+    )
+    from ome_zarr_models.v06.image import ImageAttrs as ImageAttrsV06
+    from ome_zarr_models.v06.multiscales import (
+        Dataset as DatasetV06,
+    )
+    from ome_zarr_models.v06.multiscales import (
+        Multiscale as MultiscaleV06,
+    )
+
+    zarr_group = make_valid_image_group(MemoryStore())
+    ome_group = Image.from_zarr(zarr_group)
+
+    attrs_v06 = ome_group.ome_attributes.to_version("0.6")
+    assert attrs_v06 == ImageAttrsV06(
+        version="0.6.dev4",
+        multiscales=[
+            MultiscaleV06(
+                coordinateSystems=(
+                    CoordinateSystem(
+                        name="physical",
+                        axes=(
+                            AxisV06(
+                                name="t",
+                                type="time",
+                                discrete=None,
+                                unit="millisecond",
+                                longName=None,
+                            ),
+                            AxisV06(
+                                name="c",
+                                type="channel",
+                                discrete=None,
+                                unit=None,
+                                longName=None,
+                            ),
+                            AxisV06(
+                                name="z",
+                                type="space",
+                                discrete=None,
+                                unit="micrometer",
+                                longName=None,
+                            ),
+                            AxisV06(
+                                name="y",
+                                type="space",
+                                discrete=None,
+                                unit="micrometer",
+                                longName=None,
+                            ),
+                            AxisV06(
+                                name="x",
+                                type="space",
+                                discrete=None,
+                                unit="micrometer",
+                                longName=None,
+                            ),
+                        ),
+                    ),
+                    CoordinateSystem(
+                        name="output",
+                        axes=(
+                            AxisV06(
+                                name="t",
+                                type="time",
+                                discrete=None,
+                                unit=None,
+                                longName=None,
+                            ),
+                            AxisV06(
+                                name="c",
+                                type="channel",
+                                discrete=None,
+                                unit=None,
+                                longName=None,
+                            ),
+                            AxisV06(
+                                name="z",
+                                type="space",
+                                discrete=None,
+                                unit=None,
+                                longName=None,
+                            ),
+                            AxisV06(
+                                name="y",
+                                type="space",
+                                discrete=None,
+                                unit=None,
+                                longName=None,
+                            ),
+                            AxisV06(
+                                name="x",
+                                type="space",
+                                discrete=None,
+                                unit=None,
+                                longName=None,
+                            ),
+                        ),
+                    ),
+                ),
+                datasets=(
+                    DatasetV06(
+                        path="0",
+                        coordinateTransformations=(
+                            Scale(
+                                type="scale",
+                                input=CoordinateSystemIdentifier(name=None, path="0"),
+                                output=CoordinateSystemIdentifier(
+                                    name="physical", path=None
+                                ),
+                                name=None,
+                                scale=(1.0, 1.0, 0.5, 0.5, 0.5),
+                            ),
+                        ),
+                    ),
+                    DatasetV06(
+                        path="1",
+                        coordinateTransformations=(
+                            Scale(
+                                type="scale",
+                                input=CoordinateSystemIdentifier(name=None, path="1"),
+                                output=CoordinateSystemIdentifier(
+                                    name="physical", path=None
+                                ),
+                                name=None,
+                                scale=(1.0, 1.0, 1.0, 1.0, 1.0),
+                            ),
+                        ),
+                    ),
+                    DatasetV06(
+                        path="2",
+                        coordinateTransformations=(
+                            Scale(
+                                type="scale",
+                                input=CoordinateSystemIdentifier(name=None, path="2"),
+                                output=CoordinateSystemIdentifier(
+                                    name="physical", path=None
+                                ),
+                                name=None,
+                                scale=(1.0, 1.0, 2.0, 2.0, 2.0),
+                            ),
+                        ),
+                    ),
+                ),
+                coordinateTransformations=(
+                    Scale(
+                        type="scale",
+                        input=CoordinateSystemIdentifier(name="physical", path=None),
+                        output=CoordinateSystemIdentifier(name="output", path=None),
+                        name=None,
+                        scale=(0.1, 1.0, 1.0, 1.0, 1.0),
+                    ),
+                ),
+                metadata={
+                    "description": "the fields in metadata depend on the downscaling implementation. Here, the parameters passed to the skimage function are given",
+                    "method": "skimage.transform.pyramid_gaussian",
+                    "version": "0.16.1",
+                    "args": "[true]",
+                    "kwargs": {"multichannel": True},
+                },
+                name="example",
+                type="gaussian",
+            )
+        ],
+    )

--- a/tests/v06/test_multiscales.py
+++ b/tests/v06/test_multiscales.py
@@ -409,8 +409,8 @@ def test_from_v05() -> None:
     assert (
         ms.to_version(
             "0.6",
-            default_coordinate_system="physical",
-            output_coordinate_system="output",
+            default_cs_name="physical",
+            output_cs_name="output",
         )
         == ms_target
     )


### PR DESCRIPTION
This adds a conversion function one layer up the "metadata stack", on `ImageAttrs` which is one above `Multiscale`. I'm hoping this makes it easier to convert OME-Zarr images from 0.5 to 0.6, as evidenced by the updated example.

To keep variable names a bit shorter I also renamed "output_coordinate_system" > "output_cs_name", and similarly for the default coordinate system.