### PR TITLE
Allow "0.6" as a version number

### DIFF
--- a/src/ome_zarr_models/v06/base.py
+++ b/src/ome_zarr_models/v06/base.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING, Generic, Literal, Self, TypeVar, Union
 
 import pydantic_zarr
 import pydantic_zarr.v3
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 from ome_zarr_models.base import BaseAttrsv3, BaseGroup
+from ome_zarr_models.exceptions import ValidationWarning
 
 if TYPE_CHECKING:
     import zarr
@@ -19,6 +21,20 @@ class BaseOMEAttrs(BaseAttrsv3):
 
     # TODO: change this to 0.6 before final release!
     version: Literal["0.6.dev4"]
+
+    @field_validator("version", mode="before")
+    @classmethod
+    def _parse_version(cls, version: str) -> Literal["0.6.dev4"]:
+        if version == "0.6.dev4":
+            return "0.6.dev4"
+        elif version == "0.6":
+            warnings.warn(
+                "Version number is '0.6', converting to '0.6.dev4'",
+                ValidationWarning,
+                stacklevel=2,
+            )
+            return "0.6.dev4"
+        raise ValueError(f"Invalid version: '{version}'. Must be '0.6' or '0.6.dev4'.")
 
 
 T = TypeVar("T", bound=BaseOMEAttrs)


### PR DESCRIPTION
Fixes https://github.com/ome-zarr-models/ome-zarr-models-py/issues/457