### PR TITLE
feat: add converter from 0.4 -> 06

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -40,7 +40,7 @@ jobs:
         run: uv run --python ${{ matrix.python-version }} pytest --record-mode=none
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/src/ome_zarr_models/v04/multiscales.py
+++ b/src/ome_zarr_models/v04/multiscales.py
@@ -93,8 +93,8 @@ class Multiscale(BaseAttrs):
             return self._to_v05().to_version(
                 "0.6",
                 default_coordinate_system=default_coordinate_system,
-                output_coordinate_system=output_coordinate_system
-                )
+                output_coordinate_system=output_coordinate_system,
+            )
         else:
             raise ValueError(f"Unsupported version conversion: 0.4 -> {version}")
 

--- a/src/ome_zarr_models/v04/multiscales.py
+++ b/src/ome_zarr_models/v04/multiscales.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import warnings
 from collections import Counter
-from typing import TYPE_CHECKING, Any, Literal, Self
+from typing import TYPE_CHECKING, Any, Literal, Self, overload
 
 from pydantic import (
     BaseModel,
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
 
     from ome_zarr_models.v05.multiscales import Dataset as DatasetV05
     from ome_zarr_models.v05.multiscales import Multiscale as MultiscaleV05
+    from ome_zarr_models.v06.multiscales import Multiscale as MultiscaleV06
 
 
 __all__ = ["Dataset", "Multiscale"]
@@ -58,15 +59,42 @@ class Multiscale(BaseAttrs):
     type: JsonValue = None
     version: Literal["0.4"] | None = None
 
+    @overload
     def to_version(self, version: Literal["0.5"]) -> MultiscaleV05:
+        pass
+
+    @overload
+    def to_version(
+        self,
+        version: Literal["0.6"],
+        *,
+        default_coordinate_system: str = "physical",
+        output_coordinate_system: str = "output",
+    ) -> MultiscaleV06:
+        pass
+
+    def to_version(
+        self,
+        version: Literal["0.5", "0.6"],
+        *,
+        default_coordinate_system: str = "physical",
+        output_coordinate_system: str = "output",
+    ) -> MultiscaleV05 | MultiscaleV06:
         """
         Convert this Multiscale metadata to the specified version.
 
         Currently supports conversions:
         - from 0.4 to 0.5
+        - from 0.4 to 0.6
         """
         if version == "0.5":
             return self._to_v05()
+        elif version == "0.6":
+            return self._to_v05().to_version(
+                "0.6",
+                default_coordinate_system=default_coordinate_system,
+                output_coordinate_system=output_coordinate_system
+                )
         else:
             raise ValueError(f"Unsupported version conversion: 0.4 -> {version}")
 

--- a/src/ome_zarr_models/v04/multiscales.py
+++ b/src/ome_zarr_models/v04/multiscales.py
@@ -90,10 +90,9 @@ class Multiscale(BaseAttrs):
         if version == "0.5":
             return self._to_v05()
         elif version == "0.6":
-            return self._to_v05().to_version(
-                "0.6",
-                default_coordinate_system=default_coordinate_system,
-                output_coordinate_system=output_coordinate_system,
+            return self._to_v05()._to_v06(
+                default_cs_name=default_coordinate_system,
+                output_cs_name=output_coordinate_system,
             )
         else:
             raise ValueError(f"Unsupported version conversion: 0.4 -> {version}")


### PR DESCRIPTION
I realized that it's possible to convert from 0.4 -> 0.5 and also from 0.5 -> 0.6, but it's **not** possible to do 0.4 ->0.6, which is a very straightforward (and useful thing) to do by just wrapping 0.4 -> 0.5 -> 0.6 into a single conversion call.

This PR adds that feature. Not sure we need tests there because both the 0.4->05 and 0.5 -> 0.6 conversions are already covered.