### PR TITLE
Remove unnecessary files from distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.sdist]
 exclude = [
+    ".gitmodules",
     "codecov.yml",
     "mkdocs.yml",
     ".pre-commit-config.yaml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,12 +49,26 @@ source = "vcs"
 requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.sdist]
+exclude = [
+    "codecov.yml",
+    "mkdocs.yml",
+    ".pre-commit-config.yaml",
+    ".readthedocs.yml",
+    ".cache/*",
+    ".github/*",
+    ".vscode/*",
+    "tests/*",
+    "scripts/*"
+]
+
 [dependency-groups]
 docs = ["ome-zarr-models[docs]"]
 dev = [
     "mypy==1.18.2",
     "ruff==0.13.2",
     "pre-commit==4.3.0",
+    "build==1.5.0",
 ]
 test = [
     "pytest==8.4.2",


### PR DESCRIPTION
This was inspired by @jo-mueller saying the submodule in the tests was causing issues - this might make the package pip installable from a remote source now? Either way it slims down the package quite a bit in terms of size.