### PR TITLE
Drop support for Python 3.11

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.11"
+          - "3.12"
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@ The usual classes can be found in the API reference in the sidebar.
 
 ### Other fixes/improvements
 
+- Drop support for Python 3.11. The new minimum version of Python is 3.12.
 - Add explicit support for Python 3.14.
   This requires `pydantic-zarr >= 0.10.0`, which is specified in the dependencies of `ome-zarr-models`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "ome-zarr-models"
 dynamic = ["version"]
 description = "A minimal Python package for reading OME-Zarr (meta)data "
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = [
     "numpy",
     "pydantic >= 2.11.5, <2.13",
@@ -14,7 +14,7 @@ dependencies = [
 maintainers = [{ name = "David Stansby" }]
 license = { file = "LICENSE" }
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Programming Language :: Python",


### PR DESCRIPTION
Support is long gone in SPEC 0: https://scientific-python.org/specs/spec-0000/, and this is required to use `transformnd`.