### PR TITLE
Project axis field requirements

### DIFF
--- a/src/ome_zarr_models/v06/coordinate_transforms.py
+++ b/src/ome_zarr_models/v06/coordinate_transforms.py
@@ -816,7 +816,7 @@ class ProjectAxis(Transform):
     @classmethod
     def _created_outputs_unique(
         cls, createdOutputs: tuple[int, ...] | None
-        ) -> tuple[int, ...] | None:
+    ) -> tuple[int, ...] | None:
         """
         Ensures that the positions in createdOutputs are unique.
         """
@@ -828,7 +828,7 @@ class ProjectAxis(Transform):
     @classmethod
     def _dropped_inputs_unique(
         cls, droppedInputs: tuple[int, ...] | None
-        ) -> tuple[int, ...] | None:
+    ) -> tuple[int, ...] | None:
         """
         Ensures that the positions in droppedInputs are unique.
         """
@@ -844,7 +844,7 @@ class ProjectAxis(Transform):
         if self.createdOutputs is None and self.droppedInputs is None:
             raise ValueError(
                 "At least one of 'createdOutputs' or 'droppedInputs' must be set."
-                )
+            )
         return self
 
     @property

--- a/src/ome_zarr_models/v06/coordinate_transforms.py
+++ b/src/ome_zarr_models/v06/coordinate_transforms.py
@@ -812,6 +812,26 @@ class ProjectAxis(Transform):
         description="Array of positions at which to drop dimensions.",
     )
 
+    @field_validator("createdOutputs", mode="after")
+    @classmethod
+    def _ensure_unique_created_outputs(cls, createdOutputs: tuple[int, ...] | None) -> tuple[int, ...] | None:
+        """
+        Ensures that the positions in createdOutputs are unique.
+        """
+        if createdOutputs is not None:
+            unique_items_validator(list(createdOutputs))
+        return createdOutputs
+
+    @field_validator("droppedInputs", mode="after")
+    @classmethod
+    def _ensure_unique_dropped_inputs(cls, droppedInputs: tuple[int, ...] | None) -> tuple[int, ...] | None:
+        """
+        Ensures that the positions in droppedInputs are unique.
+        """
+        if droppedInputs is not None:
+            unique_items_validator(list(droppedInputs))
+        return droppedInputs
+
     @model_validator(mode="after")
     def _ensure_either_created_or_dropped(self: Self) -> Self:
         """

--- a/src/ome_zarr_models/v06/coordinate_transforms.py
+++ b/src/ome_zarr_models/v06/coordinate_transforms.py
@@ -799,18 +799,27 @@ class ProjectAxis(Transform):
     """
 
     type: Literal["projectAxis"] = "projectAxis"
-    createdOutputs: tuple[int, ...] = Field(
-        ...,
+    createdOutputs: tuple[int, ...] | None = Field(
+        default=None,
         min_length=1,
         max_length=3,
         description="Positions at which to insert zeros in coordinate vector",
     )
-    droppedInputs: tuple[int, ...] = Field(
-        ...,
+    droppedInputs: tuple[int, ...] | None = Field(
+        default=None,
         min_length=1,
         max_length=3,
         description="Array of positions at which to drop dimensions.",
     )
+
+    @model_validator(mode="after")
+    def _ensure_either_created_or_dropped(self: Self) -> Self:
+        """
+        Ensures that at least one of createdOutputs or droppedInputs is given.
+        """
+        if self.createdOutputs is None and self.droppedInputs is None:
+            raise ValueError("At least one of 'createdOutputs' or 'droppedInputs' must be set.")
+        return self
 
     @property
     def has_inverse(self) -> bool:

--- a/src/ome_zarr_models/v06/coordinate_transforms.py
+++ b/src/ome_zarr_models/v06/coordinate_transforms.py
@@ -814,7 +814,9 @@ class ProjectAxis(Transform):
 
     @field_validator("createdOutputs", mode="after")
     @classmethod
-    def _ensure_unique_created_outputs(cls, createdOutputs: tuple[int, ...] | None) -> tuple[int, ...] | None:
+    def _created_outputs_unique(
+        cls, createdOutputs: tuple[int, ...] | None
+        ) -> tuple[int, ...] | None:
         """
         Ensures that the positions in createdOutputs are unique.
         """
@@ -824,7 +826,9 @@ class ProjectAxis(Transform):
 
     @field_validator("droppedInputs", mode="after")
     @classmethod
-    def _ensure_unique_dropped_inputs(cls, droppedInputs: tuple[int, ...] | None) -> tuple[int, ...] | None:
+    def _dropped_inputs_unique(
+        cls, droppedInputs: tuple[int, ...] | None
+        ) -> tuple[int, ...] | None:
         """
         Ensures that the positions in droppedInputs are unique.
         """
@@ -838,7 +842,9 @@ class ProjectAxis(Transform):
         Ensures that at least one of createdOutputs or droppedInputs is given.
         """
         if self.createdOutputs is None and self.droppedInputs is None:
-            raise ValueError("At least one of 'createdOutputs' or 'droppedInputs' must be set.")
+            raise ValueError(
+                "At least one of 'createdOutputs' or 'droppedInputs' must be set."
+                )
         return self
 
     @property

--- a/tests/v06/test_coordinate_transforms.py
+++ b/tests/v06/test_coordinate_transforms.py
@@ -289,9 +289,11 @@ def test_project_axis_both_none() -> None:
     """Test that ProjectAxis raises an error when both fields are None."""
     with pytest.raises(
         ValidationError,
-        match=re.escape("At least one of 'createdOutputs' or 'droppedInputs' must be set."),
+        match=re.escape(
+            "At least one of 'createdOutputs' or 'droppedInputs' must be set."
+            ),
     ):
-        ProjectAxis()  # type: ignore[call-arg]
+        ProjectAxis()
 
 
 def test_project_axis_created_outputs_only() -> None:

--- a/tests/v06/test_coordinate_transforms.py
+++ b/tests/v06/test_coordinate_transforms.py
@@ -12,6 +12,7 @@ from ome_zarr_models.v06.coordinate_transforms import (
     Identity,
     MapAxis,
     NoAffineError,
+    ProjectAxis,
     Rotation,
     Scale,
     Sequence,
@@ -282,3 +283,27 @@ def test_none_rotation() -> None:
         ValidationError, match="Provided matrix is not a pure rotation matrix"
     ):
         Rotation(rotation=((0, 2), (-1, 0)))
+
+
+def test_project_axis_both_none() -> None:
+    """Test that ProjectAxis raises an error when both fields are None."""
+    with pytest.raises(
+        ValidationError,
+        match=re.escape("At least one of 'createdOutputs' or 'droppedInputs' must be set."),
+    ):
+        ProjectAxis()  # type: ignore[call-arg]
+
+
+def test_project_axis_created_outputs_only() -> None:
+    """Test that ProjectAxis accepts only createdOutputs."""
+    pa = ProjectAxis(createdOutputs=(0, 1))
+    assert pa.createdOutputs == (0, 1)
+    assert pa.droppedInputs is None
+
+
+def test_project_axis_dropped_inputs_only() -> None:
+    """Test that ProjectAxis accepts only droppedInputs."""
+    pa = ProjectAxis(droppedInputs=(2,))
+    assert pa.droppedInputs == (2,)
+    assert pa.createdOutputs is None
+

--- a/tests/v06/test_coordinate_transforms.py
+++ b/tests/v06/test_coordinate_transforms.py
@@ -291,7 +291,7 @@ def test_project_axis_both_none() -> None:
         ValidationError,
         match=re.escape(
             "At least one of 'createdOutputs' or 'droppedInputs' must be set."
-            ),
+        ),
     ):
         ProjectAxis()
 
@@ -308,4 +308,3 @@ def test_project_axis_dropped_inputs_only() -> None:
     pa = ProjectAxis(droppedInputs=(2,))
     assert pa.droppedInputs == (2,)
     assert pa.createdOutputs is None
-


### PR DESCRIPTION
Follow-up to #465 - noticed that the implementation would always required both `droppedInputs` and `createdOutputs` to be present, which is not the case. I made both fields optional and added a validator + tests to make sure that one of these fields is always present.