### PR TITLE
feat: bump version to 0.6

### DIFF
--- a/docs/tutorial.py
+++ b/docs/tutorial.py
@@ -78,7 +78,7 @@ plt.imshow(zarr_arr, cmap="gray")
 array_specs: list[AnyArraySpec] = [
     ArraySpec(
         shape=(100, 100),
-        data_type=np.uint16,
+        data_type=np.uint8,
         chunk_grid=NamedConfig(
             name="regular",
             configuration={"chunk_shape": [32, 32]},
@@ -93,7 +93,7 @@ array_specs: list[AnyArraySpec] = [
     ),
     ArraySpec(
         shape=(100, 100),
-        data_type=np.uint16,
+        data_type=np.uint8,
         chunk_grid=NamedConfig(
             name="regular",
             configuration={"chunk_shape": [32, 32]},

--- a/docs/tutorial.py
+++ b/docs/tutorial.py
@@ -131,14 +131,14 @@ pprint(ome_zarr_image)
 #
 # For numpy arrays:
 
-arr0 = np.zeros(shape=(100, 100), dtype=np.uint16)
-arr1 = np.zeros(shape=(50, 50), dtype=np.uint16)
+arr0 = np.zeros(shape=(100, 100), dtype=np.uint8)
+arr1 = np.zeros(shape=(50, 50), dtype=np.uint8)
 array_specs = [ArraySpec.from_array(arr0), ArraySpec.from_array(arr1)]
 
 # or for Zarr arrays:
 
-arr_zarr0 = zarr.zeros(shape=(100, 100), dtype=np.uint16, zarr_format=2)
-arr_zarr1 = zarr.zeros(shape=(50, 50), dtype=np.uint16, zarr_format=2)
+arr_zarr0 = zarr.zeros(shape=(100, 100), dtype=np.uint8, zarr_format=2)
+arr_zarr1 = zarr.zeros(shape=(50, 50), dtype=np.uint8, zarr_format=2)
 array_specs = [ArraySpec.from_array(arr_zarr0), ArraySpec.from_array(arr_zarr1)]
 
 # ## Saving datasets

--- a/src/ome_zarr_models/v05/image.py
+++ b/src/ome_zarr_models/v05/image.py
@@ -91,7 +91,7 @@ class ImageAttrs(BaseOMEAttrs):
         from ome_zarr_models.v06.image import ImageAttrs as ImageAttrsV06
 
         return ImageAttrsV06(
-            version="0.6.dev4",
+            version="0.6",
             multiscales=[
                 m.to_version(
                     "0.6",

--- a/src/ome_zarr_models/v06/base.py
+++ b/src/ome_zarr_models/v06/base.py
@@ -19,21 +19,20 @@ class BaseOMEAttrs(BaseAttrsv3):
     Base class for OME-Zarr 0.6 attributes.
     """
 
-    # TODO: change this to 0.6 before final release!
-    version: Literal["0.6.dev4"]
+    version: Literal["0.6"]
 
     @field_validator("version", mode="before")
     @classmethod
-    def _parse_version(cls, version: str) -> Literal["0.6.dev4"]:
-        if version == "0.6.dev4":
-            return "0.6.dev4"
-        elif version == "0.6":
+    def _parse_version(cls, version: str) -> Literal["0.6"]:
+        if version == "0.6":
+            return "0.6"
+        elif version == "0.6.dev4":
             warnings.warn(
-                "Version number is '0.6', converting to '0.6.dev4'",
+                "Version number is '0.6.dev4', converting to '0.6'",
                 ValidationWarning,
                 stacklevel=2,
             )
-            return "0.6.dev4"
+            return "0.6"
         raise ValueError(f"Invalid version: '{version}'. Must be '0.6' or '0.6.dev4'.")
 
 

--- a/src/ome_zarr_models/v06/image.py
+++ b/src/ome_zarr_models/v06/image.py
@@ -158,7 +158,7 @@ class Image(BaseGroupv06[ImageAttrs]):
                     multiscales=[
                         multimeta,
                     ],
-                    version="0.6.dev4",
+                    version="0.6",
                 )
             ),
         )

--- a/src/ome_zarr_models/v06/scene.py
+++ b/src/ome_zarr_models/v06/scene.py
@@ -107,7 +107,7 @@ class Scene(BaseGroupv06[BaseSceneAttrs]):
                         coordinateTransformations=tuple(coord_transforms),
                         coordinateSystems=tuple(coord_systems),
                     ),
-                    version="0.6.dev4",
+                    version="0.6",
                 )
             ),
         )

--- a/src/ome_zarr_models/v06/well_types.py
+++ b/src/ome_zarr_models/v06/well_types.py
@@ -37,6 +37,6 @@ class WellMeta(CommonWellMeta):
     images: Annotated[list[WellImage], AfterValidator(unique_items_validator)] = Field(  # type: ignore[assignment]
         ..., description="Images within a well"
     )
-    version: Literal["0.6.dev4"] | None = Field(
+    version: Literal["0.6"] | None = Field(
         None, description="Version of the well specification"
     )

--- a/tests/data/examples/v06/bioformats2raw_example.json
+++ b/tests/data/examples/v06/bioformats2raw_example.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6",
     "bioformats2raw.layout": 3,
     "plate": {
       "columns": [

--- a/tests/data/examples/v06/hcs_example.json
+++ b/tests/data/examples/v06/hcs_example.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "",
     "plate": {
       "version": "0.6.dev4",
       "acquisitions": [

--- a/tests/data/examples/v06/hcs_example.json
+++ b/tests/data/examples/v06/hcs_example.json
@@ -1,8 +1,8 @@
 {
   "ome": {
-    "version": "",
+    "version": "0.6",
     "plate": {
-      "version": "0.6.dev4",
+      "version": "0.6",
       "acquisitions": [
         {
           "id": 1,

--- a/tests/data/examples/v06/image_example.json
+++ b/tests/data/examples/v06/image_example.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6",
     "multiscales": [
       {
         "name": "example",

--- a/tests/data/examples/v06/image_label_example.json
+++ b/tests/data/examples/v06/image_label_example.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6",
     "image-label": {
       "colors": [
         {

--- a/tests/data/examples/v06/labels_example.json
+++ b/tests/data/examples/v06/labels_example.json
@@ -1,6 +1,6 @@
 {
   "ome": {
     "labels": ["cell_space_segmentation"],
-    "version": "0.6.dev4"
+    "version": "0.6"
   }
 }

--- a/tests/data/examples/v06/labels_image_example.json
+++ b/tests/data/examples/v06/labels_image_example.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6",
     "multiscales": [
       {
         "name": "example",

--- a/tests/data/examples/v06/plate_example_1.json
+++ b/tests/data/examples/v06/plate_example_1.json
@@ -1,8 +1,8 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6",
     "plate": {
-      "version": "0.6.dev4",
+      "version": "0.6",
       "acquisitions": [
         {
           "id": 1,

--- a/tests/data/examples/v06/plate_example_2.json
+++ b/tests/data/examples/v06/plate_example_2.json
@@ -1,8 +1,8 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6",
     "plate": {
-      "version": "0.6.dev4",
+      "version": "0.6",
       "acquisitions": [
         {
           "id": 1,

--- a/tests/data/examples/v06/stitched_tiles_2d.zarr/tile_0/zarr.json
+++ b/tests/data/examples/v06/stitched_tiles_2d.zarr/tile_0/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6",
       "multiscales": [
         {
           "name": "multiscales",

--- a/tests/data/examples/v06/stitched_tiles_2d.zarr/tile_1/zarr.json
+++ b/tests/data/examples/v06/stitched_tiles_2d.zarr/tile_1/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6",
       "multiscales": [
         {
           "name": "multiscales",

--- a/tests/data/examples/v06/stitched_tiles_2d.zarr/zarr.json
+++ b/tests/data/examples/v06/stitched_tiles_2d.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6",
       "scene": {
         "coordinateTransformations": [
           {

--- a/tests/data/examples/v06/well_example.json
+++ b/tests/data/examples/v06/well_example.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6",
     "well": {
       "images": [
         {
@@ -20,7 +20,7 @@
           "path": "3"
         }
       ],
-      "version": "0.6.dev4"
+      "version": "0.6"
     }
   }
 }

--- a/tests/v05/test_image.py
+++ b/tests/v05/test_image.py
@@ -274,7 +274,7 @@ def test_image_convert_v06() -> None:
 
     attrs_v06 = ome_group.ome_attributes.to_version("0.6")
     assert attrs_v06 == ImageAttrsV06(
-        version="0.6.dev4",
+        version="0.6",
         multiscales=[
             MultiscaleV06(
                 coordinateSystems=(

--- a/tests/v05/test_multiscales.py
+++ b/tests/v05/test_multiscales.py
@@ -502,7 +502,7 @@ def test_from_zarr_missing_array(store: Store) -> None:
     Test that creating a multiscale Group fails when an expected Zarr array is missing
     or is a group instead of an array
     """
-    arrays = np.zeros((10, 10)), np.zeros((5, 5))
+    arrays = np.zeros((10, 10), dtype="uint8"), np.zeros((5, 5), dtype="uint8")
     group_path = "broken"
     arrays_names = ("s0", "s1")
     group_model = Image.new(
@@ -529,7 +529,7 @@ def test_from_zarr_ectopic_group(store: Store) -> None:
     Test that creating a multiscale Group fails when an expected Zarr array is missing
     or is a group instead of an array
     """
-    arrays = np.zeros((10, 10)), np.zeros((5, 5))
+    arrays = np.zeros((10, 10), dtype="uint8"), np.zeros((5, 5), dtype="uint8")
     group_path = "broken"
     arrays_names = ("s0", "s1")
     group_model = Image.new(

--- a/tests/v06/test_collection.py
+++ b/tests/v06/test_collection.py
@@ -28,7 +28,7 @@ def test_load_container() -> None:
             node_type="group",
             attributes={
                 "ome": {
-                    "version": "0.6.dev4",
+                    "version": "0.6",
                     "multiscales": [
                         {
                             "coordinateSystems": (
@@ -110,7 +110,7 @@ def test_load_container() -> None:
             node_type="group",
             attributes={
                 "ome": {
-                    "version": "0.6.dev4",
+                    "version": "0.6",
                     "multiscales": [
                         {
                             "coordinateSystems": (
@@ -189,7 +189,7 @@ def test_load_container() -> None:
         ),
     }
     assert container.ome_attributes == BaseSceneAttrs(
-        version="0.6.dev4",
+        version="0.6",
         scene=SceneAttrs(
             coordinateTransformations=(
                 Translation(
@@ -356,4 +356,4 @@ def test_scene_new() -> None:
     assert scene.ome_attributes.scene.coordinateSystems[0].name == "world"
 
     # Verify version
-    assert scene.ome_attributes.version == "0.6.dev4"
+    assert scene.ome_attributes.version == "0.6"

--- a/tests/v06/test_hcs.py
+++ b/tests/v06/test_hcs.py
@@ -40,9 +40,9 @@ def test_hcs(store: Store) -> None:
                 WellInPlate(path="B/2", rowIndex=1, columnIndex=1),
                 WellInPlate(path="B/3", rowIndex=1, columnIndex=2),
             ],
-            version="0.6.dev4",
+            version="0.6",
         ),
-        version="0.6.dev4",
+        version="0.6",
     )
     well_groups = list(ome_group.well_groups)
     assert len(well_groups) == 0

--- a/tests/v06/test_image.py
+++ b/tests/v06/test_image.py
@@ -37,7 +37,7 @@ def test_image(store: Store) -> None:
     )
     ome_group = Image.from_zarr(zarr_group)
     image_attrs = ImageAttrs(
-        version="0.6.dev4",
+        version="0.6",
         multiscales=[
             Multiscale(
                 coordinateSystems=(
@@ -254,7 +254,7 @@ def test_image_new() -> None:
         ),
     }
     assert image.ome_attributes == ImageAttrs(
-        version="0.6.dev4",
+        version="0.6",
         multiscales=[
             Multiscale(
                 coordinateSystems=(

--- a/tests/v06/test_image_label.py
+++ b/tests/v06/test_image_label.py
@@ -42,7 +42,7 @@ def test_image_label(store: Store) -> None:
     )
     ome_group = ImageLabel.from_zarr(zarr_group)
     assert ome_group.attributes.ome == ImageLabelAttrs(
-        version="0.6.dev4",
+        version="0.6",
         image_label=Label(
             colors=(
                 Color(label_value=0, rgba=(0, 0, 128, 128)),

--- a/tests/v06/test_labels.py
+++ b/tests/v06/test_labels.py
@@ -25,7 +25,7 @@ def test_labels(store: Store) -> None:
 
     ome_group = Labels.from_zarr(zarr_group)
     assert ome_group.attributes.ome == LabelsAttrs(
-        labels=["cell_space_segmentation"], version="0.6.dev4"
+        labels=["cell_space_segmentation"], version="0.6"
     )
 
 

--- a/tests/v06/test_plate.py
+++ b/tests/v06/test_plate.py
@@ -45,7 +45,7 @@ def test_example_plate_json(store: Store) -> None:
             WellInPlate(path="B/2", rowIndex=1, columnIndex=1),
             WellInPlate(path="B/3", rowIndex=1, columnIndex=2),
         ],
-        version="0.6.dev4",
+        version="0.6",
     )
 
 
@@ -95,7 +95,7 @@ def test_example_plate_json_2(store: Store) -> None:
             WellInPlate(path="C/5", rowIndex=2, columnIndex=4),
             WellInPlate(path="D/7", rowIndex=3, columnIndex=6),
         ],
-        version="0.6.dev4",
+        version="0.6",
     )
 
 

--- a/tests/v06/test_scene.py
+++ b/tests/v06/test_scene.py
@@ -6,7 +6,7 @@ from ome_zarr_models.v06 import Scene
 SCENE_URL = "https://uk1s3.embassy.ebi.ac.uk/idr/zarr/test-data/v0.6.dev3/idr0050/4995115_output_to_ms.zarr/"
 
 
-# TODO: Update data on remote storage to reflect 0.6.dev4 changes
+# TODO: Update data on remote storage to reflect 0.6 changes
 @pytest.mark.xfail
 @pytest.mark.vcr
 def test_load_scene() -> None:

--- a/tests/v06/test_well.py
+++ b/tests/v06/test_well.py
@@ -10,7 +10,7 @@ def test_well(store: Store) -> None:
     zarr_group = json_to_zarr_group(json_fname="well_example.json", store=store)
     ome_group = Well.from_zarr(zarr_group)
     assert ome_group.attributes.ome == WellAttrs(
-        version="0.6.dev4",
+        version="0.6",
         well=WellMeta(
             images=[
                 WellImage(path="0", acquisition=1),
@@ -18,7 +18,7 @@ def test_well(store: Store) -> None:
                 WellImage(path="2", acquisition=2),
                 WellImage(path="3", acquisition=2),
             ],
-            version="0.6.dev4",
+            version="0.6",
         ),
     )
 
@@ -31,7 +31,7 @@ def test_get_paths() -> None:
             WellImage(path="2", acquisition=2),
             WellImage(path="3", acquisition=2),
         ],
-        version="0.6.dev4",
+        version="0.6",
     )
 
     assert well.get_acquisition_paths() == {1: ["0", "1"], 2: ["2", "3"]}
@@ -45,7 +45,7 @@ def test_well_image_constraint() -> None:
             WellImage(path="2-1", acquisition=2),
             WellImage(path="3-1", acquisition=2),
         ],
-        version="0.6.dev4",
+        version="0.6",
     )
 
     assert well.get_acquisition_paths() == {1: ["0_1", "1_1"], 2: ["2-1", "3-1"]}
@@ -57,7 +57,7 @@ def test_well_image_constraint_fails_period() -> None:
             images=[
                 WellImage(path=".", acquisition=1),
             ],
-            version="0.6.dev4",
+            version="0.6",
         )
 
 
@@ -67,7 +67,7 @@ def test_well_image_constraint_fails_double_underscore() -> None:
             images=[
                 WellImage(path="__image", acquisition=1),
             ],
-            version="0.6.dev4",
+            version="0.6",
         )
 
 
@@ -77,7 +77,7 @@ def test_well_image_constraint_fails_double_period() -> None:
             images=[
                 WellImage(path="..", acquisition=1),
             ],
-            version="0.6.dev4",
+            version="0.6",
         )
 
 
@@ -87,7 +87,7 @@ def test_well_image_constraint_fails_empty() -> None:
             images=[
                 WellImage(path="", acquisition=1),
             ],
-            version="0.6.dev4",
+            version="0.6",
         )
 
 
@@ -98,5 +98,5 @@ def test_well_image_constraint_fails_disallowed_chars(path: str) -> None:
             images=[
                 WellImage(path=path, acquisition=1),
             ],
-            version="0.6.dev4",
+            version="0.6",
         )


### PR DESCRIPTION
Model classes currently internally convert version from 0.6 to 0.6.dev4-

I am switching this around in this PR:
- 0.6rc0 is backwards-compatible with 0.6.dev4, so dev4 datasets should pass as valid
- If 0.6 is specified, it also be written now.