### PR TITLE
feat: remove `version` key in plate/well metadata

### DIFF
--- a/src/ome_zarr_models/v06/plate.py
+++ b/src/ome_zarr_models/v06/plate.py
@@ -2,8 +2,6 @@
 For reference, see the [plate section of the OME-Zarr specification](https://ngff.openmicroscopy.org/0.5/index.html#plate-md).
 """
 
-from pydantic import Field
-
 from ome_zarr_models.common.plate import (
     Acquisition,
     Column,
@@ -20,10 +18,6 @@ __all__ = [
     "WellInPlate",
 ]
 
-
-class Plate(PlateBase):
-    """
-    A single plate.
-    """
-
-    version: str = Field(description="Version of the plate specification")
+# Plate is just PlateBase in v06.
+# The version key lives on HCSAttrs (via BaseOMEAttrs).
+Plate = PlateBase

--- a/src/ome_zarr_models/v06/well_types.py
+++ b/src/ome_zarr_models/v06/well_types.py
@@ -1,4 +1,5 @@
-from typing import Annotated, Literal
+from collections import defaultdict
+from typing import Annotated
 
 from pydantic import AfterValidator, Field
 
@@ -8,7 +9,6 @@ from ome_zarr_models.common.validation import (
     unique_items_validator,
     validate_zarr_node_name,
 )
-from ome_zarr_models.common.well_types import WellMeta as CommonWellMeta
 
 __all__ = ["WellImage", "WellMeta"]
 
@@ -29,14 +29,26 @@ class WellImage(BaseAttrs):
     )
 
 
-class WellMeta(CommonWellMeta):
+# ponytail: No version here—lives on WellAttrs via BaseOMEAttrs in v06
+class WellMeta(BaseAttrs):
     """
     Metadata for a single well.
     """
 
-    images: Annotated[list[WellImage], AfterValidator(unique_items_validator)] = Field(  # type: ignore[assignment]
+    images: Annotated[list[WellImage], AfterValidator(unique_items_validator)] = Field(
         ..., description="Images within a well"
     )
-    version: Literal["0.6"] | None = Field(
-        None, description="Version of the well specification"
-    )
+
+    def get_acquisition_paths(self) -> dict[int, list[str]]:
+        """
+        Get mapping from acquisition indices to corresponding paths.
+        """
+        acquisition_dict: dict[int, list[str]] = defaultdict(list)
+        for image in self.images:
+            if image.acquisition is None:
+                raise ValueError(
+                    "Cannot get acquisition paths for Zarr files without "
+                    "'acquisition' metadata at the well level"
+                )
+            acquisition_dict[image.acquisition].append(image.path)
+        return dict(acquisition_dict)

--- a/tests/data/examples/v06/plate_example_1.json
+++ b/tests/data/examples/v06/plate_example_1.json
@@ -2,7 +2,6 @@
   "ome": {
     "version": "0.6",
     "plate": {
-      "version": "0.6",
       "acquisitions": [
         {
           "id": 1,

--- a/tests/data/examples/v06/plate_example_2.json
+++ b/tests/data/examples/v06/plate_example_2.json
@@ -2,7 +2,6 @@
   "ome": {
     "version": "0.6",
     "plate": {
-      "version": "0.6",
       "acquisitions": [
         {
           "id": 1,

--- a/tests/v06/test_plate.py
+++ b/tests/v06/test_plate.py
@@ -45,7 +45,6 @@ def test_example_plate_json(store: Store) -> None:
             WellInPlate(path="B/2", rowIndex=1, columnIndex=1),
             WellInPlate(path="B/3", rowIndex=1, columnIndex=2),
         ],
-        version="0.6",
     )
 
 
@@ -95,7 +94,6 @@ def test_example_plate_json_2(store: Store) -> None:
             WellInPlate(path="C/5", rowIndex=2, columnIndex=4),
             WellInPlate(path="D/7", rowIndex=3, columnIndex=6),
         ],
-        version="0.6",
     )
 
 
@@ -104,7 +102,6 @@ def test_unique_column_names() -> None:
         Plate(
             columns=[Column(name="col1"), Column(name="col1")],
             rows=[Row(name="row1")],
-            version="0.4",
             wells=[WellInPlate(path="path1", rowIndex=1, columnIndex=1)],
         )
 
@@ -114,7 +111,6 @@ def test_unique_row_names() -> None:
         Plate(
             columns=[Column(name="col1")],
             rows=[Row(name="row1"), Row(name="row1")],
-            version="0.4",
             wells=[WellInPlate(path="path1", rowIndex=1, columnIndex=1)],
         )
 
@@ -146,6 +142,5 @@ def test_well_paths(well_path: str, msg: str) -> None:
         Plate(
             columns=[Column(name="col1")],
             rows=[Row(name="row1")],
-            version="0.4",
             wells=[WellInPlate(path=well_path, rowIndex=1, columnIndex=1)],
         )


### PR DESCRIPTION
To whom it may concern: This PR corrects some of the classes around Plates and Wells in the v06 metadata. I think already in v05, we didn't need the `version` key under the `plate` or `well` fields in the metadata, but it was still written (schemas and spec were a bit out of sync there).

Correct:

```json
"ome": {
  "version": ...,
  "plate": {...}
  }
```

Semi-incorrect:

```json
"ome": {
  "version": ...,
  "plate": {
    "version": ...
    }
  }
```

In v06, this is corrected, so we can simplify some things here.

cc @will-moore @dstansby @kevinyamauchi @jni

With this merged, I think I would cut a release for 1.9.0 instead of the pre-releases.