### PR TITLE
fix: fields for byDimension have changed

### DIFF
--- a/src/ome_zarr_models/v06/coordinate_transforms.py
+++ b/src/ome_zarr_models/v06/coordinate_transforms.py
@@ -737,8 +737,8 @@ class ByDimensionTransform(BaseAttrs):
     transformation: AnyTransform = Field(
         ..., description="The coordinate transformation."
     )
-    input_axes: tuple[int, ...] = Field(..., description="Input axes indices.")
-    output_axes: tuple[int, ...] = Field(..., description="Output axes indices.")
+    inputAxes: tuple[int, ...] = Field(..., description="Input axes indices.")
+    outputAxes: tuple[int, ...] = Field(..., description="Output axes indices.")
 
     @property
     def has_inverse(self) -> bool:
@@ -747,8 +747,8 @@ class ByDimensionTransform(BaseAttrs):
     def get_inverse(self) -> ByDimensionTransform:
         return ByDimensionTransform(
             transformation=self.transformation.get_inverse(),
-            input_axes=self.output_axes,
-            output_axes=self.input_axes,
+            inputAxes=self.outputAxes,
+            outputAxes=self.inputAxes,
         )
 
 
@@ -777,9 +777,9 @@ class ByDimension(Transform):
         point_in = list(point)
         point_out = point_in.copy()
         for t in self.transformations:
-            coord_in = tuple(point_in[i] for i in t.input_axes)
+            coord_in = tuple(point_in[i] for i in t.inputAxes)
             coord_out = t.transformation.transform_point(coord_in)
-            for coord, i in zip(coord_out, t.output_axes, strict=True):
+            for coord, i in zip(coord_out, t.outputAxes, strict=True):
                 point_out[i] = coord
 
         return tuple(point_out)

--- a/tests/v06/test_coordinate_transforms.py
+++ b/tests/v06/test_coordinate_transforms.py
@@ -107,13 +107,13 @@ def test_inverse(transform: Transform, inverse_expected: Transform) -> None:
                 transformations=(
                     ByDimensionTransform(
                         transformation=Scale(scale=(4,)),
-                        input_axes=(2,),
-                        output_axes=(1,),
+                        inputAxes=(2,),
+                        outputAxes=(1,),
                     ),
                     ByDimensionTransform(
                         transformation=Translation(translation=(0.1, 0.3)),
-                        input_axes=(1, 0),
-                        output_axes=(0, 2),
+                        inputAxes=(1, 0),
+                        outputAxes=(0, 2),
                     ),
                 )
             ),
@@ -142,13 +142,13 @@ def test_transform_point(
                 transformations=(
                     ByDimensionTransform(
                         transformation=Scale(scale=(4,)),
-                        input_axes=(2,),
-                        output_axes=(1,),
+                        inputAxes=(2,),
+                        outputAxes=(1,),
                     ),
                     ByDimensionTransform(
                         transformation=Translation(translation=(0.1, 0.3)),
-                        input_axes=(1, 0),
-                        output_axes=(0, 2),
+                        inputAxes=(1, 0),
+                        outputAxes=(0, 2),
                     ),
                 )
             ),


### PR DESCRIPTION
The fields for the byDimension transform were still `input_axes` and `output_axes`, but had changed to CamelCase in 0.6rc0 of the ngff-spec (see https://ngff.openmicroscopy.org/specifications/dev/version_history.html#changed)